### PR TITLE
Allow multiple lines in retro items

### DIFF
--- a/web/app/components/retro_column_input.js
+++ b/web/app/components/retro_column_input.js
@@ -65,7 +65,7 @@ class RetroColumnInput extends React.Component {
   }
 
   onKeyPress(event) {
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' && !event.shiftKey) {
       if(event.target.value !== '') {
         this.submitRetroItem();
       }

--- a/web/app/components/retro_item_edit_view.js
+++ b/web/app/components/retro_item_edit_view.js
@@ -76,9 +76,8 @@ class RetroItemEditView extends React.Component {
   onKeyPress(event) {
     const {editedText} = this.state;
     const value = event.target.value;
-
-    if (event.key === 'Enter' && value && value.trim().length > 0) {
-      this.props.saveItem(editedText);
+    if (event.key === 'Enter' && !event.shiftKey && value && value.trim().length > 0) {
+          this.props.saveItem(editedText);
     }
   }
 

--- a/web/app/stylesheets/_app.scss
+++ b/web/app/stylesheets/_app.scss
@@ -743,8 +743,11 @@ button:focus {
     overflow-wrap: break-word;
     font-weight: bold;
     font-size: 1.3rem;
-    line-height: 1.2;
     white-space: pre-line;
+
+    button {
+      line-height: 1.1;
+    }
 
     span {
       @extend .show-for-small-only;

--- a/web/app/stylesheets/_app.scss
+++ b/web/app/stylesheets/_app.scss
@@ -744,6 +744,7 @@ button:focus {
     font-weight: bold;
     font-size: 1.3rem;
     line-height: 1.2;
+    white-space: pre-line;
 
     span {
       @extend .show-for-small-only;

--- a/web/spec/app/components/retro_column_input_spec.js
+++ b/web/spec/app/components/retro_column_input_spec.js
@@ -92,6 +92,13 @@ describe('inputting an action item', () => {
     expect('textarea').toHaveValue('');
   });
 
+  it('does not submit when pressing shift + enter so new line is added', () => {
+    $('textarea').val('a new action item').simulate('change');
+
+    $('textarea').simulate('keyPress', {key: 'Enter', shiftKey: true});
+    expect('createRetroActionItem').not.toHaveBeenDispatched();
+  });
+
   it('doesn\'t add an item when pressing enter on an empty input field', () => {
     $('textarea').val('').simulate('change');
     $('textarea').simulate('keyPress', {key: 'Enter'});

--- a/web/spec/app/components/retro_item_edit_view_spec.js
+++ b/web/spec/app/components/retro_item_edit_view_spec.js
@@ -79,6 +79,13 @@ describe('RetroItemEditView', () => {
       sharedUpdateActionBehavior();
     });
 
+    it('does not submit when pressing shift + enter so new line is added', () => {
+      $('textarea').val('a new action item').simulate('change');
+
+      $('textarea').simulate('keyPress', {key: 'Enter', shiftKey: true});
+      expect(saveSpy).not.toHaveBeenCalled();
+    });
+
     it('does not allow editing if value is empty', () => {
       $('textarea').val('').simulate('change');
       $('.edit-save').simulate('click');


### PR DESCRIPTION
In some scenarios it is desirable to add more information to a retro item, for example action items of the format:

> Improve this thing
> * Subpoint 1
> * Subpoint 2

This PR enable this by not submitting an item when the shift key is pressed at the same time as the enter key, by restricting this a new line is entered.

Also made a small tweak to increase the line height of items to 1.1 so items with new lines or that wrap are easier to read.

* [X] I have reviewed the [contributing guide]
* [x] I have made this pull request to the `master` branch
* [X] I have run all the API unit tests using `bundle exec rake` from the `/api` submodule.
* [X] I have run all the WEB unit tests using `gulp spec-app` from the `/web` submodule.
* [X] I have run all the acceptance tests using `gulp local-acceptance` from the `/web` submodule.
* [N/A] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added
