### PR TITLE
Auto facilitation

### DIFF
--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -50,3 +50,12 @@ Metrics/MethodLength:
 
 Bundler/OrderedGems:
   Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Layout/FirstParameterIndentation:
+  Enabled: false
+
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false

--- a/api/app/controllers/transitions_controller.rb
+++ b/api/app/controllers/transitions_controller.rb
@@ -1,0 +1,61 @@
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+class TransitionsController < ApplicationController
+  before_action :load_retro, :authenticate_retro
+
+  def transitions
+    transition = params.require(:transition)
+
+    if transition != 'NEXT'
+      render json: :nothing, status: 400
+      return
+    end
+
+    unless @retro.highlighted_item_id.nil?
+      previous_item = @retro.items.find(@retro.highlighted_item_id)
+      previous_item.done = true
+      previous_item.save!
+    end
+
+    next_item = @retro.items.find { |item| !item.done }
+
+    if next_item.nil?
+      @retro.highlighted_item_id = nil
+    else
+      @retro.highlighted_item_id = next_item.id
+      @retro.retro_item_end_time = 5.minutes.from_now
+    end
+
+    @retro.save!
+    RetrosChannel.broadcast(@retro)
+    render 'retros/show'
+  end
+end

--- a/api/app/domain/happy_meh_sad_order_rule.rb
+++ b/api/app/domain/happy_meh_sad_order_rule.rb
@@ -1,0 +1,73 @@
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+class HappyMehSadOrderRule
+  def initialize(chain = NoOpRule.new)
+    @chain = chain
+  end
+
+  def apply(retro, items)
+    columns = split_columns(items)
+    ordered_categories = column_order(retro)
+
+    ordered_items = retro.items.map {
+      [columns[ordered_categories[0]].shift,
+       columns[ordered_categories[1]].shift,
+       columns[ordered_categories[2]].shift].compact
+    }
+    @chain.apply(retro, ordered_items.flatten)
+  end
+
+  def split_columns(items)
+    happy, remainder = items.partition { |item| item.category == 'happy' }
+    meh, sad = remainder.partition { |item| item.category == 'meh' }
+    {
+      'happy' => happy,
+      'meh' => meh,
+      'sad' => sad
+    }
+  end
+
+  def column_order(retro)
+    last_category = 'sad'
+    unless retro.highlighted_item_id.nil?
+      last_category = retro.items.find(retro.highlighted_item_id).category
+    end
+
+    if last_category == 'happy'
+      ['meh', 'sad', 'happy']
+    elsif last_category == 'meh'
+      ['sad', 'happy', 'meh']
+    else
+      ['happy', 'meh', 'sad']
+    end
+  end
+end

--- a/api/app/domain/no_op_rule.rb
+++ b/api/app/domain/no_op_rule.rb
@@ -28,34 +28,9 @@
 #
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-class TransitionsController < ApplicationController
-  before_action :load_retro, :authenticate_retro
 
-  def transitions
-    transition = params.require(:transition)
-
-    if transition != 'NEXT'
-      render json: :nothing, status: 400
-      return
-    end
-
-    unless @retro.highlighted_item_id.nil?
-      previous_item = @retro.items.find(@retro.highlighted_item_id)
-      previous_item.done = true
-      previous_item.save!
-    end
-
-    next_item = RetroFacilitator.new.facilitate(@retro).first
-
-    if next_item.nil?
-      @retro.highlighted_item_id = nil
-    else
-      @retro.highlighted_item_id = next_item.id
-      @retro.retro_item_end_time = 5.minutes.from_now
-    end
-
-    @retro.save!
-    RetrosChannel.broadcast(@retro)
-    render 'retros/show'
+class NoOpRule
+  def apply(_, items)
+    items
   end
 end

--- a/api/app/domain/ordered_by_vote_rule.rb
+++ b/api/app/domain/ordered_by_vote_rule.rb
@@ -28,34 +28,14 @@
 #
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-class TransitionsController < ApplicationController
-  before_action :load_retro, :authenticate_retro
 
-  def transitions
-    transition = params.require(:transition)
+class OrderedByVoteRule
+  def initialize(chain = NoOpRule.new)
+    @chain = chain
+  end
 
-    if transition != 'NEXT'
-      render json: :nothing, status: 400
-      return
-    end
-
-    unless @retro.highlighted_item_id.nil?
-      previous_item = @retro.items.find(@retro.highlighted_item_id)
-      previous_item.done = true
-      previous_item.save!
-    end
-
-    next_item = RetroFacilitator.new.facilitate(@retro).first
-
-    if next_item.nil?
-      @retro.highlighted_item_id = nil
-    else
-      @retro.highlighted_item_id = next_item.id
-      @retro.retro_item_end_time = 5.minutes.from_now
-    end
-
-    @retro.save!
-    RetrosChannel.broadcast(@retro)
-    render 'retros/show'
+  def apply(retro, items)
+    sorted = items.sort { |first, second| second.vote_count <=> first.vote_count }
+    @chain.apply(retro, sorted)
   end
 end

--- a/api/app/domain/retro_facilitator.rb
+++ b/api/app/domain/retro_facilitator.rb
@@ -28,34 +28,16 @@
 #
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-class TransitionsController < ApplicationController
-  before_action :load_retro, :authenticate_retro
+#
 
-  def transitions
-    transition = params.require(:transition)
+class RetroFacilitator
+  def facilitate(retro)
+    rules = NoDoneItemsRule.new(
+        EndWithHappiestRule.new(
+            OrderedByVoteRule.new(
+                HappyMehSadOrderRule.new
+            )))
 
-    if transition != 'NEXT'
-      render json: :nothing, status: 400
-      return
-    end
-
-    unless @retro.highlighted_item_id.nil?
-      previous_item = @retro.items.find(@retro.highlighted_item_id)
-      previous_item.done = true
-      previous_item.save!
-    end
-
-    next_item = RetroFacilitator.new.facilitate(@retro).first
-
-    if next_item.nil?
-      @retro.highlighted_item_id = nil
-    else
-      @retro.highlighted_item_id = next_item.id
-      @retro.retro_item_end_time = 5.minutes.from_now
-    end
-
-    @retro.save!
-    RetrosChannel.broadcast(@retro)
-    render 'retros/show'
+    rules.apply(retro, retro.items)
   end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -50,6 +50,8 @@ Rails.application.routes.draw do
       patch 'done', to: :done, controller: 'items'
       post 'vote', to: :vote, controller: 'items'
     end
-    resource :discussion, only: [:create, :destroy, :update]
+    resource :discussion, only: [:create, :destroy, :update] do
+      post 'transitions', controller: 'transitions'
+    end
   end
 end

--- a/api/spec/domain/happy_meh_sad_order_rule_spec.rb
+++ b/api/spec/domain/happy_meh_sad_order_rule_spec.rb
@@ -1,0 +1,73 @@
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+describe HappyMehSadOrderRule do
+  let(:retro) {
+    user = User.create!(email: 'me@example.com')
+    Retro.create!(name: 'My Retro', user: user)
+  }
+
+  it 'should revolve through happy, meh, sad starting from type of previously highlighted item' do
+    meh1 = Item.create!(retro: retro, description: 'Meh Item 1', category: :meh, vote_count: 1)
+    meh2 = Item.create!(retro: retro, description: 'Meh Item 2', category: :meh, vote_count: 1)
+    sad1 = Item.create!(retro: retro, description: 'Sad Item 1', category: :sad, vote_count: 1)
+    hap1 = Item.create!(retro: retro, description: 'Happy Item 1', category: :happy, vote_count: 1)
+    hap2 = Item.create!(retro: retro, description: 'Happy Item 2', category: :happy, vote_count: 1)
+    retro.highlighted_item_id = meh1.id
+
+    items = HappyMehSadOrderRule.new.apply(retro, retro.items)
+    expect(items).to eq([sad1, hap1, meh1, hap2, meh2])
+  end
+
+  it 'should return first happy when no highlighted item' do
+    sad1 = Item.create!(retro: retro, description: 'Sad Item 1', category: :sad, vote_count: 1)
+    meh1 = Item.create!(retro: retro, description: 'Meh Item 1', category: :meh, vote_count: 1)
+    hap1 = Item.create!(retro: retro, description: 'Happy Item 1', category: :happy, vote_count: 1)
+
+    items = HappyMehSadOrderRule.new.apply(retro, retro.items)
+    expect(items).to eq([hap1, meh1, sad1])
+  end
+
+  it 'should return first meh when no happy' do
+    sad1 = Item.create!(retro: retro, description: 'Sad Item 1', category: :sad, vote_count: 1)
+    meh1 = Item.create!(retro: retro, description: 'Meh Item 1', category: :meh, vote_count: 1)
+
+    items = HappyMehSadOrderRule.new.apply(retro, retro.items)
+    expect(items).to eq([meh1, sad1])
+  end
+
+  it 'should return first sad when no happy or meh' do
+    sad1 = Item.create!(retro: retro, description: 'Sad Item 1', category: :sad, vote_count: 1)
+
+    items = HappyMehSadOrderRule.new.apply(retro, retro.items)
+    expect(items).to eq([sad1])
+  end
+end

--- a/api/spec/domain/retro_facilitator_spec.rb
+++ b/api/spec/domain/retro_facilitator_spec.rb
@@ -1,0 +1,52 @@
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+describe RetroFacilitator do
+  let(:retro) {
+    user = User.create!(email: 'me@example.com')
+    Retro.create!(name: 'My Retro', user: user)
+  }
+
+  describe 'facilitate' do
+    it 'should apply expected rules' do
+      Item.create!(retro: retro, description: 'done', done: true, category: :happy, vote_count: 1)
+      most_happy = Item.create!(retro: retro, description: 'most happy', category: :happy, vote_count: 20)
+      happy1 = Item.create!(retro: retro, description: 'happy1', category: :happy, vote_count: 1)
+      meh1 = Item.create!(retro: retro, description: 'meh1', category: :meh, vote_count: 1)
+      sad1 = Item.create!(retro: retro, description: 'sad1', category: :sad, vote_count: 1)
+      sad2 = Item.create!(retro: retro, description: 'sad2', category: :sad, vote_count: 2)
+
+      items = RetroFacilitator.new.facilitate(retro)
+
+      expect(items).to eq([happy1, meh1, sad2, sad1, most_happy])
+    end
+  end
+end

--- a/api/spec/requests/transitions_request_spec.rb
+++ b/api/spec/requests/transitions_request_spec.rb
@@ -1,0 +1,103 @@
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+require 'rails_helper'
+
+describe '/retros/:retro_id/discussion/transition' do
+  let(:retro) { Retro.create!(name: 'My Retro', password: 'the-password', video_link: 'the-video-link') }
+  let(:token) { ActionController::HttpAuthentication::Token.encode_credentials(retro.auth_token) }
+
+  describe 'POST' do
+    it 'selects next item when no previous item highlighted' do
+      allow(RetrosChannel).to receive_messages(broadcast: {})
+      item = retro.items.create!(description: 'first item', category: :happy)
+
+      post retro_path(retro) + '/discussion/transitions',
+           headers: { HTTP_AUTHORIZATION: token },
+           params: { transition: 'NEXT' },
+           as: :json
+
+      retro.reload
+      expect(retro.highlighted_item_id).to eq(item.id)
+
+      expect(RetrosChannel).to have_received(:broadcast).with(retro).ordered
+      data = JSON.parse(response.body)
+      expect(data['retro']['highlighted_item_id']).to eq(item.id)
+      expect(data['retro']['retro_item_end_time']).not_to be_nil
+    end
+
+    it 'marks previously hilighted item as done if there was one' do
+      allow(RetrosChannel).to receive_messages(broadcast: {})
+      item = retro.items.create!(description: 'first item', done: true, category: :happy)
+      item2 = retro.items.create!(description: 'second item', category: :meh)
+      retro.highlighted_item_id = item.id
+
+      post retro_path(retro) + '/discussion/transitions',
+           headers: { HTTP_AUTHORIZATION: token },
+           params: { transition: 'NEXT' },
+           as: :json
+
+      retro.reload
+
+      expect(retro.highlighted_item_id).to eq(item2.id)
+      expect(RetrosChannel).to have_received(:broadcast).with(retro).ordered
+      data = JSON.parse(response.body)
+      expect(data['retro']['highlighted_item_id']).to eq(item2.id)
+      expect(data['retro']['retro_item_end_time']).not_to be_nil
+    end
+
+    it 'sets highlighted item to nil if the last item was finished' do
+      allow(RetrosChannel).to receive_messages(broadcast: {})
+      item = retro.items.create!(description: 'first item', done: true, category: :happy)
+      retro.highlighted_item_id = item.id
+
+      post retro_path(retro) + '/discussion/transitions',
+           headers: { HTTP_AUTHORIZATION: token },
+           params: { transition: 'NEXT' },
+           as: :json
+
+      retro.reload
+
+      expect(retro.highlighted_item_id).to eq(nil)
+      data = JSON.parse(response.body)
+      expect(data['retro']['highlighted_item_id']).to be_nil
+      expect(data['retro']['retro_item_end_time']).to be_nil
+    end
+
+    it 'fails with 400 when transition is not NEXT' do
+      post retro_path(retro) + '/discussion/transitions',
+           headers: { HTTP_AUTHORIZATION: token },
+           params: { transition: 'SOME_OTHER_TRANSITION' },
+           as: :json
+
+      expect(response.status).to eq(400)
+    end
+  end
+end

--- a/e2e/spec/felicity_journey_spec.rb
+++ b/e2e/spec/felicity_journey_spec.rb
@@ -236,6 +236,44 @@ context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'tru
     end
   end
 
+ specify 'Auto facilitation journey' do
+    register('felicity-auto-facilitate-user')
+    create_public_retro('first-retro')
+    retro_url = create_public_retro('auto-facilitate-retro')
+    visit retro_url
+
+    fill_in("I'm glad that...", with: 'something happy 1')
+    find('.column-happy textarea.retro-item-add-input').native.send_keys(:return)
+    fill_in("I'm wondering about...", with: 'something meh 1')
+    find('.column-meh textarea.retro-item-add-input').native.send_keys(:return)
+    fill_in("It wasn't so great that...", with: 'something sad 1')
+    find('.column-sad textarea.retro-item-add-input').native.send_keys(:return)
+
+    def send_right_key
+      # Chrome web driver only allows sending key events on focusable elements, this button has a tabindex so is focusable
+      keyEventReciever = first('.retro-heading-button a')
+      keyEventReciever.native.send_keys(:right)
+    end
+
+    send_right_key
+    expect(page).to have_css('.highlight .item-text', text: 'something happy 1')
+
+    # Should not affect right keypresses in textareas
+    keyEventReciever = first('.retro-item-add-input')
+    keyEventReciever.native.send_keys(:right)
+    sleep(0.5)
+    expect(page).to have_css('.highlight .item-text', text: 'something happy 1')
+
+    send_right_key
+    expect(page).to have_css('.highlight .item-text', text: 'something meh 1')
+
+    send_right_key
+    expect(page).to have_css('.highlight .item-text', text: 'something sad 1')
+
+    sleep(0.5)
+    send_right_key
+    expect(page).to have_content('The board will be cleared ready for your next retro and incomplete action items will be carried across.')
+  end
 
   specify 'Journey' do
     logout

--- a/e2e/spec/felicity_journey_spec.rb
+++ b/e2e/spec/felicity_journey_spec.rb
@@ -242,6 +242,15 @@ context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'tru
     retro_url = create_public_retro('auto-facilitate-retro')
     visit retro_url
 
+    fill_in("I'm glad that...", with: 'something really happy')
+    find('.column-happy textarea.retro-item-add-input').native.send_keys(:return)
+    within('div.retro-item', text: 'something really happy') do
+      4.times do |index|
+        find('.item-vote-submit').click
+        expect(page).to have_content(index + 1)
+      end
+    end
+
     fill_in("I'm glad that...", with: 'something happy 1')
     find('.column-happy textarea.retro-item-add-input').native.send_keys(:return)
     fill_in("I'm wondering about...", with: 'something meh 1')
@@ -270,8 +279,11 @@ context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'tru
     send_right_key
     expect(page).to have_css('.highlight .item-text', text: 'something sad 1')
 
-    sleep(0.5)
     send_right_key
+    expect(page).to have_css('.highlight .item-text', text: 'something really happy')
+
+    send_right_key
+    sleep(0.5)
     expect(page).to have_content('The board will be cleared ready for your next retro and incomplete action items will be carried across.')
   end
 

--- a/web/app/api/retro_api.js
+++ b/web/app/api/retro_api.js
@@ -136,6 +136,16 @@ const RetroApi = {
       accessToken: token});
   },
 
+  nextRetroItem(retro_id, token) {
+      return fetchJson(`${this.apiBaseUrl()}/retros/${retro_id}/discussion/transitions`, {
+          method: 'POST',
+          accessToken: token,
+          body: JSON.stringify({
+              transition: 'NEXT'
+          })
+      });
+  },
+
   highlightRetroItem(retro_id, item_id, token) {
     return fetchJson(`${this.apiBaseUrl()}/retros/${retro_id}/discussion`, {
       method: 'POST',

--- a/web/app/components/show_retro_page.js
+++ b/web/app/components/show_retro_page.js
@@ -44,6 +44,7 @@ const RetroWebsocket = require('./retro_websocket');
 const RetroFooter = require('./footer');
 import { RetroLegalBanner } from './retro_legal_banner';
 import RetroHeading from './retro_heading';
+import {HotKeys} from 'react-hotkeys';
 
 const EmptyPage = require('./empty_page');
 const jQuery = require('jquery');
@@ -149,6 +150,14 @@ class ShowRetroPage extends React.Component {
     return jQuery.grep(items, function (item) {
       return item.archived_at === timestamp;
     });
+  }
+
+  moveToNextItem(event) {
+    if(event.target.type === "textarea") {
+      return;
+    }
+    const {retroId} = this.props;
+    Actions.nextRetroItem({retro_id: retroId});
   }
 
   getArchivesTimestamps(archivesTimestamps, items) {
@@ -286,51 +295,62 @@ class ShowRetroPage extends React.Component {
     );
   }
 
-  renderDesktop(retro) {
-    const {config: {websocket_url}, retroId, archives} = this.props;
-    const {isMobile} = this.state;
-    let retroContainerClasses = 'full-height full-height-retro';
+    renderDesktop(retro) {
+        const {config: {websocket_url}, retroId, archives} = this.props;
+        const {isMobile} = this.state;
+        let retroContainerClasses = 'full-height full-height-retro';
 
-    if (archives) {
-      retroContainerClasses += ' archived';
+        if (archives) {
+            retroContainerClasses += ' archived';
+        }
+
+        const keyMap = {
+            'next': 'right'
+        };
+
+        const keyHandlers = {
+            'next': this.moveToNextItem.bind(this)
+        };
+
+        return (
+            <HotKeys keyMap={keyMap} handlers={keyHandlers}>
+                <span>
+                  <RetroWebsocket url={websocket_url} retro_id={retroId}/>
+                    {this.renderArchiveConfirmationDialog()}
+                    <div className={retroContainerClasses}>
+
+                    <RetroLegalBanner retro={retro}/>
+
+                    <RetroHeading retro={retro} retroId={retroId} isMobile={this.state.isMobile} archives={archives}
+                                  showVideoButton={!archives}/>
+                    <div className="retro-item-list">
+                      <RetroColumn category="happy"
+                                   retro={retro}
+                                   retroId={retroId}
+                                   archives={archives}
+                                   isMobile={isMobile}/>
+                      <RetroColumn category="meh"
+                                   retro={retro}
+                                   retroId={retroId}
+                                   archives={archives}
+                                   isMobile={isMobile}/>
+                      <RetroColumn category="sad"
+                                   retro={retro}
+                                   retroId={retroId}
+                                   archives={archives}
+                                   isMobile={isMobile}/>
+                    </div>
+                    <RetroActionPanel
+                        retro={retro}
+                        retroId={retroId}
+                        isMobile={isMobile}
+                        archives={archives}/>
+                    <RetroFooter/>
+                  </div>
+                </span>
+            </HotKeys>
+        );
     }
-
-    return (
-      <span>
-        <RetroWebsocket url={websocket_url} retro_id={retroId}/>
-        {this.renderArchiveConfirmationDialog()}
-        <div className={retroContainerClasses}>
-
-          <RetroLegalBanner retro={retro}/>
-
-          <RetroHeading retro={retro} retroId={retroId} isMobile={this.state.isMobile} archives={archives} showVideoButton={!archives}/>
-          <div className="retro-item-list">
-            <RetroColumn category="happy"
-                         retro={retro}
-                         retroId={retroId}
-                         archives={archives}
-                         isMobile={isMobile}/>
-            <RetroColumn category="meh"
-                         retro={retro}
-                         retroId={retroId}
-                         archives={archives}
-                         isMobile={isMobile}/>
-            <RetroColumn category="sad"
-                         retro={retro}
-                         retroId={retroId}
-                         archives={archives}
-                         isMobile={isMobile}/>
-          </div>
-          <RetroActionPanel
-            retro={retro}
-            retroId={retroId}
-            isMobile={isMobile}
-            archives={archives}/>
-          <RetroFooter/>
-        </div>
-      </span>
-    );
-  }
 
   render() {
     const {retro, archives} = this.props;

--- a/web/app/dispatchers/api_dispatcher.js
+++ b/web/app/dispatchers/api_dispatcher.js
@@ -140,6 +140,12 @@ const ApiDispatcher = {
       this.dispatch({type: 'retroItemSuccessfullyVoted', data: {item: data.item}});
     });
   },
+  nextRetroItem({data: {retro_id}}) {
+      Logger.info('nextRetroItem');
+      return RetroApi.nextRetroItem(retro_id, getApiToken(retro_id)).then(() => {
+          this.dispatch({type: 'checkAllRetroItemsDone'});
+      })
+  },
   highlightRetroItem({data: {retro_id, item}}) {
     Logger.info('highlightRetroItem');
     RetroApi.highlightRetroItem(retro_id, item.id, getApiToken(retro_id)).then(([, data]) => {

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "lodash.debounce": "^4.0.3",
     "react-autosize-textarea": "^0.3.4",
     "react-helmet": "^3.1.0",
+    "react-hotkeys": "^1.1.4",
     "react-scroll": "^1.4.7",
     "thenify": "^3.2.0",
     "url-join": "1.1.0"

--- a/web/spec/app/dispatchers/api_dispatcher_spec.js
+++ b/web/spec/app/dispatchers/api_dispatcher_spec.js
@@ -695,6 +695,32 @@ describe('ApiDispatcher', () => {
     });
   });
 
+  describe('nextRetroItem', () => {
+    it('makes an API POST to /retros/:id/discussion/transition', () => {
+      spyOn(window.localStorage, 'getItem').and.returnValue('the-token');
+      subject.$store = new Cursor({retro: retro}, cursorSpy);
+      subject.dispatch({type: 'nextRetroItem', data: {retro_id: 1}});
+
+      expect('/retros/1/discussion/transition').toHaveBeenRequestedWith({
+        method: 'POST',
+        requestHeaders: {
+          'accept': 'application/json',
+          'content-type': 'application/json',
+          'authorization': 'Bearer the-token'
+        },
+        data: {transition: 'NEXT'}
+      });
+
+      const request = jasmine.Ajax.requests.mostRecent();
+      request.succeed({retro: retro});
+      MockPromises.tickAllTheWay();
+
+      expect('checkAllRetroItemsDone').toHaveBeenDispatchedWith({
+        type: 'checkAllRetroItemsDone'
+      });
+    });
+
+  });
   describe('highlightRetroItem', () => {
     let item;
     beforeEach(() => {


### PR DESCRIPTION
Run the retro automatically by pressing the right arrow key to select the next item and mark the current item as done.

Structured around a series of heuristic rules on how to run a retro, to start off with:
  * Exclude done items
  * Keep happiest item until last
  * Run through items in voting order
  * Run through items in happy -> meh -> sad order

Also made RuboCop rules less restrictive but can back this out if you can advise on how to structure the code in a way that's nicer than turning them off.

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)
* [x] I have made this pull request to the `master` branch
* [x] I have run all the API unit tests using `bundle exec rake` from the `/api` submodule.
* [x] I have run all the WEB unit tests using `gulp spec-app` from the `/web` submodule.
* [x] I have run all the acceptance tests using `gulp local-acceptance` from the `/web` submodule.
* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added
