### PR TITLE
Update and fix the PWS deploy script

### DIFF
--- a/deployment/pws/deploy.sh
+++ b/deployment/pws/deploy.sh
@@ -2,8 +2,11 @@
 
 set -e
 
-cf push -f config/manifest-api.yml -p api
+# The directory in which this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cf push -f config/manifest-api.yml -p "$SCRIPT_DIR"/assets/api
 cf run-task {{api-app-name}} 'ADMIN_EMAIL=email@example.com ADMIN_PASSWORD=password rake admin:create_user'
 
-cp config/config.js package
-cf push -f config/manifest-web.yml -p web/package
+cp config/config.js "$SCRIPT_DIR"/assets/web
+cf push -f config/manifest-web.yml -p "$SCRIPT_DIR"/assets/web


### PR DESCRIPTION
### A short explanation of the proposed change:
We did a deployment on PWS following the instructions in the release. There were some things that we had to change in the `deploy.sh` script:
- The `path` in cf push was relative, and didn't work from `package/pws`. We changed paths to be relative to the script's path. 
- The "package" directory within assets/web does not exist in the  release zip, so we removed this

### An explanation of the use cases your change solves
Hopefully, `deploy.sh` can works out of the ~box~ zip.

### Additional notes :
- We haven't run tests, we believe they don't check this file. However, we deployed a fresh version with our proposed `deploy.sh`
- We haven't taken a look the PCF deployment, but it is likely that the deploy.sh would benefit from similar changes... Might take a look later.