### PR TITLE
Focus 'Password' input prompt when a retro requires a password

### DIFF
--- a/web/app/components/login_to_retro_page.js
+++ b/web/app/components/login_to_retro_page.js
@@ -119,6 +119,7 @@ class LoginToRetroPage extends React.Component {
                        onChange={this.onInputChange.bind(this)}
                        onKeyPress={this.onKeyPress.bind(this)}
                        required={true}
+                       autoFocus={true}
                        autoComplete={false}/>
               <p className="password-terms-text">By logging in, you agree to our <a href={global.Retro.config.terms} target="_blank">Terms of Use</a> and <a href={global.Retro.config.privacy} target="_blank">Privacy Policy</a> and use of cookies.</p>
                 <div className="error-message">{errors}</div>

--- a/web/spec/app/components/login_to_retro_page_spec.js
+++ b/web/spec/app/components/login_to_retro_page_spec.js
@@ -57,6 +57,10 @@ describe('LoginToRetroPage', () => {
       expect('label').toContainText('Enter the password to access the retro name.');
     });
 
+    it('focuses the password input field', () => {
+      expect('.form-input').toBeFocused();
+    });
+
 
     describe('when clicking on the login button', () => {
       it('dispatches loginToRetro', () => {


### PR DESCRIPTION
This change will focus the "Password" field when accessing a retro that requires a password.  It saves you a whole tab keystroke, which actually add up to quite a few keystrokes over the course of a project.

Also tested this a bit on mobile devices, and it does not seem to focus on mobile, which may actually be more desirable, as autofocus on mobile is a bit of a jarring experience.