### PR TITLE
Changed created_at to DateTime so it stores the timezone

### DIFF
--- a/api/spec/mailers/archived_mailer_spec.rb
+++ b/api/spec/mailers/archived_mailer_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ArchivedMailer, type: :mailer do
     end
 
     let(:mail) do
-      archive = retro.archives.create!(created_at: Time.new(2017, 1, 1))
+      archive = retro.archives.create!(created_at: DateTime.new(2017, 1, 1))
 
       ActionItem.create!(retro: retro, description: 'An unresolved item', done: false, archive_id: archive.id)
       ActionItem.create!(retro: retro, description: 'A resolved item', done: true, archive_id: archive.id)


### PR DESCRIPTION
The archive wasn't storing the timezone for the created_at time, so the test would fail if you were in a timezone before GMT (i.e +11:00) as the resulting time would end up being the previous day. Just changing it to DateTime means the timezone is stored and the tests pass.