### PR TITLE
Gracefully handle bad JWT tokens

### DIFF
--- a/api/lib/security/retro_token.rb
+++ b/api/lib/security/retro_token.rb
@@ -11,5 +11,7 @@ class RetroToken
     decoded.first['slug'] == retro_slug
   rescue JWT::ExpiredSignature
     false
+  rescue JWT::DecodeError
+    false
   end
 end

--- a/api/spec/lib/retro_token_spec.rb
+++ b/api/spec/lib/retro_token_spec.rb
@@ -54,5 +54,14 @@ describe RetroToken do
         end
       end
     end
+
+    context 'token is invalid' do
+      it 'returns false' do
+        secret = 'secret'
+        token = 'this-cannot-be-parsed-by-jwt'
+
+        expect(RetroToken.valid?('happy-sad-meh', token, secret)).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
Previously, if you upgrade an existing deployment of Postfacto from a version that used the old token API scheme, users would experience 500 errors if they tried to use the app.

This was due to a `JWT::DecodeError` being raised by requests from clients that had the old API Token cached. This change causes `RetroToken.valid?` to return `false` in the case of a decode error, allowing users to re-authenticate and receive a new shiny JWT token and go about their day entering all manner of retro items.

Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the API unit tests using `bundle exec rake` from the `/api` submodule.

* [x] I have run all the WEB unit tests using `gulp spec-app` from the `/web` submodule.

* [x] I have run all the acceptance tests using `gulp local-acceptance` from the `/web` submodule.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added
