### PR TITLE
Add script to allow for upgrade of Heroku deployments

### DIFF
--- a/deployment/INSTRUCTIONS.md
+++ b/deployment/INSTRUCTIONS.md
@@ -36,6 +36,8 @@ So you're ready to set Postfacto up, choose names for your web and API apps. We'
 
 ## Heroku
 
+### Initial deployment
+
 1. Install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)
 1. Run the Heroku deployment script from the `heroku` directory:
 
@@ -46,6 +48,13 @@ So you're ready to set Postfacto up, choose names for your web and API apps. We'
 1. Create a retro for yourself by clicking on 'Retros' and the 'New Retro'
 1. Log in to your retro at `web-app-name.herokuapp.com/retros/you-retro-slug`
 1. Share the URL and password with your team and then run a retro!
+
+### Upgrading a deployment
+
+1. Presuming the steps in the Initial deployment section have been completed, run the Heroku upgrade script from the `heroku` directory:
+  ```bash
+  ./upgrade.sh <web-app-name> <api-app-name>
+  ```
 
 ## Configuration
 

--- a/deployment/deploy-heroku.sh
+++ b/deployment/deploy-heroku.sh
@@ -61,8 +61,8 @@ heroku config:set WEBSOCKET_PORT=4443 CLIENT_ORIGIN=https://${WEB_HOST}.herokuap
 rm -rf .git # blow away any existent git directory from a previous run
 git init .
 git add .
-git commit -m "Packaging for Heroku"
-git push --force --set-upstream https://git.heroku.com/${API_HOST}.git master
+git commit -m "Packaging for initial Heroku deployment"
+git push --set-upstream https://git.heroku.com/${API_HOST}.git master
 heroku run rake admin:create_user ADMIN_EMAIL=email@example.com ADMIN_PASSWORD=password -a ${API_HOST}
 popd
 
@@ -79,6 +79,6 @@ heroku create ${WEB_HOST} --buildpack https://github.com/heroku/heroku-buildpack
 rm -rf .git # blow away any existent git directory from a previous run
 git init .
 git add .
-git commit -m "Packaging for Heroku"
+git commit -m "Packaging for initial Heroku deployment"
 git push --set-upstream https://git.heroku.com/${WEB_HOST}.git master
 popd

--- a/deployment/upgrade-heroku.sh
+++ b/deployment/upgrade-heroku.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+set -e
+
+if [ $# -ne 2 ]; then
+  echo "usage: ./upgrade_heroku.sh <web-app-name> <api-app-name>"
+  echo "This will upgrade an existing Postfacto deployment to a .herokuapp.com host of your choosing"
+  exit 1
+fi
+
+WEB_HOST=$1
+API_HOST=$2
+
+# The directory in which this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ASSETS_DIR="$SCRIPT_DIR"/assets
+CONFIG_DIR="$SCRIPT_DIR"/config
+
+if ! heroku apps:info -a "$WEB_HOST" 2>/dev/null; then
+  echo "Web host ${WEB_HOST} does not exist! Aborting."
+  exit 1
+fi
+
+if ! heroku apps:info -a "$API_HOST" 2>/dev/null; then
+  echo "API host ${API_HOST} does not exist! Aborting."
+  exit 1
+fi
+
+###################
+# Upgrade the API
+###################
+
+pushd "$ASSETS_DIR"/api
+
+rm -rf .git # blow away any existent git directory from a previous run
+git init .
+git add .
+git commit -m "Packaging for Heroku upgrade"
+git push --force --set-upstream https://git.heroku.com/${API_HOST}.git master
+popd
+
+###########################
+# Upgrade the web frontend
+###########################
+
+cp "$CONFIG_DIR"/config.js "$ASSETS_DIR"/web/public_html
+pushd "$ASSETS_DIR"/web
+sed -i '' "s/{{api-app-name}}/${API_HOST}/" public_html/config.js
+
+rm -rf .git # blow away any existent git directory from a previous run
+git init .
+git add .
+git commit -m "Packaging for Heroku upgrade"
+git push --force --set-upstream https://git.heroku.com/${WEB_HOST}.git master
+popd

--- a/package.sh
+++ b/package.sh
@@ -43,7 +43,8 @@ cp -r web/package package/pcf/assets/web
 
 cp -r deployment/heroku package
 cp -r deployment/deploy-heroku.sh package/heroku/deploy.sh
-chmod u+x package/heroku/deploy.sh
+cp -r deployment/upgrade-heroku.sh package/heroku/upgrade.sh
+chmod u+x package/heroku/*.sh
 
 rm -rf api/tmp/*
 cp -r api/* package/heroku/assets/api


### PR DESCRIPTION
Similar to the Heroku `deploy.sh`, it's handy to be able to run a script to easily upgrade a Postfacto deployment to the latest version. This change provides a simple script that updates the deployment in place.

Note that it doesn't do any management of environment variables that may have changed between deployments, so caveat emptor applies!

==============

Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the API unit tests using `bundle exec rake` from the `/api` submodule.

* [x] I have run all the WEB unit tests using `gulp spec-app` from the `/web` submodule.

* [x] I have run all the acceptance tests using `gulp local-acceptance` from the `/web` submodule.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added
