### PR TITLE
Improve behaviour of e2e.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ package.zip
 .idea/
 .DS_Store
 node_modules/
+docker_node_modules/
 *.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,17 @@ cd web
 CI=true npm test
 ```
 
+Note that the frontend tests will run significantly faster outside the docker container.
+If you want to do this, you will need to install the dependencies again (due to architecture differences):
+
+```bash
+cd web
+npm install
+npm test
+```
+
+Both installations can coexist; the docker container will use dependencies located in docker_node_modules.
+
 ### API
 
 ```bash

--- a/docker.sh
+++ b/docker.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+mkdir -p "$(pwd)/docker_node_modules"
+
 docker run -it \
   --entrypoint /bin/bash \
   -p 3000:3000 \
   -p 4000:4000 \
   -v "$(pwd)":/postfacto \
+  -v "$(pwd)/docker_node_modules:/postfacto/web/node_modules" \
   postfacto/postfacto


### PR DESCRIPTION
This replaces the shutdown behaviour of e2e.sh with a more targeted approach.

Annoyingly, the react_scripts default behaviour causes servers which are very difficult to kill programmatically (see e.g. https://github.com/facebook/create-react-app/issues/932). The old script worked around this by killing the process group, but that is harmful when run from another script and causes a bad exit status.

This change manually traverses the process tree, killing the grandchild and child of the npm process. This causes a clean shutdown. It also silences a couple of cleanup commands to make failures easier to spot.

Finally, it updates docker.sh to mount a different directory under `node_modules`. This enables running tests both inside and outside the container without architecture conflicts (useful because frontend testing is significantly faster outside the docker container).

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added
