### PR TITLE
Add giphy support to retro items

### DIFF
--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -270,7 +270,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    shoulda-matchers (4.0.0)
+    shoulda-matchers (4.0.1)
       activesupport (>= 4.2.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -349,4 +349,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.16.2
+   1.16.6

--- a/api/app/controllers/giphy_controller.rb
+++ b/api/app/controllers/giphy_controller.rb
@@ -1,0 +1,45 @@
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+class GiphyController < ApplicationController
+  include RetrosAuth
+
+  before_action :load_and_authenticate_retro
+
+  def search
+    if GIPHY_CLIENT.supported?
+      gif_url = GIPHY_CLIENT.get_gif!(params[:q])
+
+      render json: { url: gif_url }, status: :ok
+    else
+      render json: '', status: :method_not_allowed
+    end
+  end
+end

--- a/api/config/initializers/giphy_client.rb
+++ b/api/config/initializers/giphy_client.rb
@@ -1,0 +1,36 @@
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+require 'clients/giphy_client'
+
+giphy_endpoint = ENV['GIPHY_ENDPOINT'] ||= 'https://api.giphy.com/v1/gifs/search'
+api_key = ENV.fetch('GIPHY_API_KEY') { nil }
+
+GIPHY_CLIENT = GiphyClient.new(giphy_endpoint, api_key)

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -53,5 +53,6 @@ Rails.application.routes.draw do
     resource :discussion, only: [:create, :destroy, :update] do
       post 'transitions', controller: 'transitions'
     end
+    get 'giphy', to: 'giphy#search'
   end
 end

--- a/api/lib/clients/giphy_client.rb
+++ b/api/lib/clients/giphy_client.rb
@@ -1,0 +1,55 @@
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+require 'rest-client'
+
+class GiphyClient
+  def initialize(url, api_token)
+    @url = url
+    @api_key = api_token
+  end
+
+  def supported?
+    !@api_key.nil?
+  end
+
+  def get_gif!(query)
+    response = RestClient.get(@url, params: {
+                                api_key: @api_key,
+                                q: query,
+                                limit: 1,
+                                offset: 0,
+                                rating: 'G',
+                                lang: 'en'
+                              })
+    response = JSON.parse(response.body, symbolize_names: true)
+    response.dig(:data, 0, :images, :fixed_width, :url)
+  end
+end

--- a/api/spec/clients/giphy_client_spec.rb
+++ b/api/spec/clients/giphy_client_spec.rb
@@ -1,0 +1,56 @@
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+require 'spec_helper'
+require 'clients/giphy_client'
+
+describe GiphyClient do
+  describe '.get_gif!' do
+    it 'fetches gif by query from giphy' do
+      stub_request(:get, 'http://www.example.com')
+        .with(query: {
+                api_key: 'xyz123',
+                q: 'test-query',
+                limit: 1,
+                offset: 0,
+                rating: 'G',
+                lang: 'en'
+              })
+        .to_return(
+              body: '{"data": [{"images":{"fixed_width":{"url":"http://giphy/gif"}}}]}',
+              status: 200
+            )
+
+      gif_url = GiphyClient.new('http://www.example.com', 'xyz123').get_gif! 'test-query'
+
+      expect(gif_url).to eq('http://giphy/gif')
+    end
+  end
+end

--- a/api/spec/requests/giphy_request_spec.rb
+++ b/api/spec/requests/giphy_request_spec.rb
@@ -1,0 +1,83 @@
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+require 'rails_helper'
+
+describe '/retros/:retro_id/giphy' do
+  let!(:retro) do
+    Retro.create!(name: 'My Retro', password: 'the-password', video_link: 'the-video-link', is_private: true)
+  end
+
+  let(:token) { ActionController::HttpAuthentication::Token.encode_credentials(token_for(retro)) }
+
+  describe 'GET /' do
+    context 'if password is correct' do
+      subject do
+        get retro_giphy_path(retro),
+            headers: { HTTP_AUTHORIZATION: token },
+            params: { q: 'query' },
+            as: :json
+      end
+
+      it 'returns a gif' do
+        expect(GIPHY_CLIENT).to receive(:get_gif!).with('query').and_return('http://gif.url/')
+        expect(GIPHY_CLIENT).to receive(:supported?).and_return(true)
+
+        subject
+
+        expect(response.status).to eq(200)
+        expect(response.body).to eq('{"url":"http://gif.url/"}')
+      end
+
+      context 'giphy is not available' do
+        it 'returns 405' do
+          expect(GIPHY_CLIENT).to receive(:supported?).and_return(false)
+
+          subject
+
+          expect(response.status).to eq(405)
+          expect(response.body).to eq('')
+        end
+      end
+    end
+
+    context 'if password is incorrect' do
+      subject do
+        get retro_giphy_path(retro), params: { q: 'hello' }, as: :json
+      end
+
+      it 'returns 403' do
+        subject
+
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+end

--- a/e2e/spec/felicity_journey_spec.rb
+++ b/e2e/spec/felicity_journey_spec.rb
@@ -417,6 +417,7 @@ context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'tru
     within('div.retro-item', text: 'this is a happy item') do
       find('.retro-item-cancel').click
     end
+    sleep(1)
     expect(page).not_to have_css '.highlight'
 
     # Re-highlight

--- a/web/src/api/retro_api.js
+++ b/web/src/api/retro_api.js
@@ -30,6 +30,7 @@
  */
 
 import fetchJson from '../helpers/fetch_helper';
+import {getApiToken} from '../dispatchers/api_dispatcher';
 
 export default {
   apiBaseUrl() {
@@ -241,6 +242,12 @@ export default {
         new_password,
         request_uuid,
       }),
+    });
+  },
+
+  getRetroGif(retro_id, query) {
+    return fetchJson(`${this.apiBaseUrl()}/retros/${retro_id}/giphy?q=${encodeURI(query)}`, {
+      accessToken: getApiToken(retro_id),
     });
   },
 

--- a/web/src/components/retro-show/giphy_text.jsx
+++ b/web/src/components/retro-show/giphy_text.jsx
@@ -1,0 +1,79 @@
+/*
+ * Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+ * remote teams.
+ *
+ * Copyright (C) 2016 - Present Pivotal Software, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ *
+ * it under the terms of the GNU Affero General Public License as
+ *
+ * published by the Free Software Foundation, either version 3 of the
+ *
+ * License, or (at your option) any later version.
+ *
+ *
+ *
+ * This program is distributed in the hope that it will be useful,
+ *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *
+ * GNU Affero General Public License for more details.
+ *
+ *
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {Component} from 'react';
+import PropTypes from 'prop-types';
+import Giphy from '../../helpers/giphy';
+
+export default class GiphyText extends Component {
+  static propTypes = {
+    retroId: PropTypes.string.isRequired,
+    value: PropTypes.string,
+  };
+
+  static defaultProps = {
+    value: '',
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {processed: ''};
+  }
+
+  async componentDidMount() {
+    const {retroId, value} = this.props;
+    this.setState({processed: value});
+    try {
+      const giphy = new Giphy(retroId);
+      const processed = await giphy.interpolate(value);
+      this.setState(() => ({processed}));
+    } catch {
+      // ignore
+    }
+  }
+
+  async componentWillReceiveProps(nextProps) {
+    const {retroId, value} = nextProps;
+    this.setState({processed: value});
+    try {
+      const giphy = new Giphy(retroId);
+      const processed = await giphy.interpolate(value);
+      this.setState(() => ({processed}));
+    } catch {
+      // ignore
+    }
+  }
+
+  render() {
+    const {processed} = this.state;
+    return processed;
+  }
+}

--- a/web/src/components/retro-show/giphy_text.test.jsx
+++ b/web/src/components/retro-show/giphy_text.test.jsx
@@ -1,0 +1,70 @@
+/*
+ * Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+ * remote teams.
+ *
+ * Copyright (C) 2016 - Present Pivotal Software, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ *
+ * it under the terms of the GNU Affero General Public License as
+ *
+ * published by the Free Software Foundation, either version 3 of the
+ *
+ * License, or (at your option) any later version.
+ *
+ *
+ *
+ * This program is distributed in the hope that it will be useful,
+ *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *
+ * GNU Affero General Public License for more details.
+ *
+ *
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import {mount} from 'enzyme';
+import GiphyText from './giphy_text';
+
+import '../../spec_helper';
+
+describe('GiphyText', () => {
+  it('interpolates gifs in place of giphy keywords', async () => {
+    jest.spyOn(window, 'fetch').mockResolvedValue({
+      status: 200,
+      json: () => ({
+        url: 'http://example.com/gif',
+      }),
+    });
+
+    const value = 'example /giphy search';
+    const wrapper = mount(<GiphyText retroId="testing" value={value}/>);
+    await wrapper.instance().componentDidMount();
+    wrapper.update();
+
+    expect(wrapper.text()).toEqual('example ');
+
+    const img = wrapper.find('img');
+
+    expect(img.prop('src')).toEqual('http://example.com/gif');
+    expect(img.prop('alt')).toEqual('search');
+  });
+
+  it('retains giphy keywords on error', async () => {
+    jest.spyOn(window, 'fetch').mockRejectedValue(new Error('does not work'));
+
+    const value = 'example /giphy search';
+    const wrapper = mount(<GiphyText retroId="testing" value={value}/>);
+    await wrapper.instance().componentDidMount();
+    wrapper.update();
+
+    expect(wrapper.text()).toEqual(value);
+  });
+});

--- a/web/src/components/retro-show/retro_column_item.jsx
+++ b/web/src/components/retro-show/retro_column_item.jsx
@@ -36,6 +36,7 @@ import {Actions} from 'p-flux';
 import Scroll from 'react-scroll';
 import CountdownTimer from './countdown_timer';
 import RetroItemEditView from './retro_item_edit_view';
+import GiphyText from './giphy_text';
 
 export default class RetroColumnItem extends React.Component {
   static propTypes = {
@@ -70,7 +71,8 @@ export default class RetroColumnItem extends React.Component {
   componentDidUpdate(prevProps) {
     /* eslint-disable react/no-find-dom-node */
     const {item, highlighted_item_id} = prevProps;
-    const wasHighlighted = (highlighted_item_id && highlighted_item_id === item.id);
+    const wasHighlighted =
+      highlighted_item_id && highlighted_item_id === item.id;
     if (this.isHighlighted() && !wasHighlighted) {
       const windowH = document.body.getBoundingClientRect().height;
       const itemH = ReactDOM.findDOMNode(this).offsetHeight;
@@ -92,12 +94,12 @@ export default class RetroColumnItem extends React.Component {
   // boolean checkers
   isEnabled() {
     const {item, highlighted_item_id} = this.props;
-    return (!highlighted_item_id || highlighted_item_id === item.id);
+    return !highlighted_item_id || highlighted_item_id === item.id;
   }
 
   isHighlighted() {
     const {item, highlighted_item_id} = this.props;
-    return (highlighted_item_id && highlighted_item_id === item.id);
+    return highlighted_item_id && highlighted_item_id === item.id;
   }
 
   isDone() {
@@ -184,7 +186,11 @@ export default class RetroColumnItem extends React.Component {
 
     if (isEditing && editedText.trim().length > 0) {
       this.setState({isEditing: false});
-      Actions.updateRetroItem({retro_id: retroId, item, description: editedText});
+      Actions.updateRetroItem({
+        retro_id: retroId,
+        item,
+        description: editedText,
+      });
     }
   }
 
@@ -197,10 +203,18 @@ export default class RetroColumnItem extends React.Component {
 
   // render
   renderTimer() {
-    const {item, highlighted_item_id, retro_item_end_time, retroId} = this.props;
+    const {
+      item,
+      highlighted_item_id,
+      retro_item_end_time,
+      retroId,
+    } = this.props;
     if (item.id === highlighted_item_id) {
       return (
-        <CountdownTimer endTimestampInMs={Date.parse(retro_item_end_time)} retroId={retroId}/>
+        <CountdownTimer
+          endTimestampInMs={Date.parse(retro_item_end_time)}
+          retroId={retroId}
+        />
       );
     }
     return null;
@@ -213,8 +227,12 @@ export default class RetroColumnItem extends React.Component {
       return (
         <div className="item-footer">
           <br/>
-          <div className="retro-item-cancel" onClick={this.onItemCancelClicked}>Cancel</div>
-          <div className="item-done" onClick={this.onItemDoneClicked}>Done</div>
+          <div className="retro-item-cancel" onClick={this.onItemCancelClicked}>
+            Cancel
+          </div>
+          <div className="item-done" onClick={this.onItemDoneClicked}>
+            Done
+          </div>
         </div>
       );
     }
@@ -231,7 +249,9 @@ export default class RetroColumnItem extends React.Component {
     return (
       <div className="item-vote">
         <div className="item-vote-submit" onClick={this.onItemVoteClicked}>
-          <div className="vote-icon"><i className="fa fa-heart" aria-hidden="true"/></div>
+          <div className="vote-icon">
+            <i className="fa fa-heart" aria-hidden="true"/>
+          </div>
           <div className="vote-count">{this.props.item.vote_count}</div>
         </div>
       </div>
@@ -253,11 +273,12 @@ export default class RetroColumnItem extends React.Component {
   }
 
   renderDescription() {
-    const {item} = this.props;
-
+    const {retroId, item: {description}} = this.props;
     return (
       <div className="item-text">
-        <button type="button">{item.description}</button>
+        <button type="button">
+          <GiphyText retroId={retroId} value={description}/>
+        </button>
       </div>
     );
   }
@@ -296,7 +317,12 @@ export default class RetroColumnItem extends React.Component {
       );
     }
     return (
-      <div id={this.domId()} key={item.id} className={'retro-item' + this.getPrimaryClass()} onClick={this.onItemClicked}>
+      <div
+        id={this.domId()}
+        key={item.id}
+        className={'retro-item' + this.getPrimaryClass()}
+        onClick={this.onItemClicked}
+      >
         {itemContent}
       </div>
     );

--- a/web/src/components/retro-show/retro_column_item.test.jsx
+++ b/web/src/components/retro-show/retro_column_item.test.jsx
@@ -36,6 +36,7 @@ import {Dispatcher} from 'p-flux';
 import '../../spec_helper';
 
 import RetroColumnItem from './retro_column_item';
+import GiphyText from './giphy_text';
 
 describe('RetroColumnItem', () => {
   const retroId = 'retro-slug-123';
@@ -283,5 +284,13 @@ describe('RetroColumnItem', () => {
       dom.find('.item-done').simulate('click');
       expect(Dispatcher).not.toHaveReceived('doneRetroItem');
     });
+  });
+
+  it('renders the description in a giphy tag', () => {
+    const dom = mount(<RetroColumnItem retroId={retroId} item={item} highlighted_item_id={2} archives={false} isMobile/>);
+    const giphy = dom.find(GiphyText);
+
+    expect(giphy.prop('retroId')).toEqual(retroId);
+    expect(giphy.prop('value')).toEqual(item.description);
   });
 });

--- a/web/src/dispatchers/main_dispatcher.js
+++ b/web/src/dispatchers/main_dispatcher.js
@@ -75,7 +75,6 @@ export default {
   getRetroLoginSuccessfullyReceived({data}) {
     this.$store.merge({retro: data.retro});
   },
-
   retroNotFound() {
     this.$store.merge({retro_not_found: true});
   },

--- a/web/src/helpers/fetch_helper.js
+++ b/web/src/helpers/fetch_helper.js
@@ -45,6 +45,9 @@ export default function fetchJson(url, {accessToken, headers, ...options} = {}) 
       if (response.status === 204) {
         return [response.status, ''];
       }
+      if (response.status === 405) {
+        return [response.status, ''];
+      }
       return Promise.all([response.status, response.json()]);
     })
     .catch(() => {

--- a/web/src/helpers/giphy.jsx
+++ b/web/src/helpers/giphy.jsx
@@ -1,0 +1,95 @@
+/*
+ * Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+ * remote teams.
+ *
+ * Copyright (C) 2016 - Present Pivotal Software, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ *
+ * it under the terms of the GNU Affero General Public License as
+ *
+ * published by the Free Software Foundation, either version 3 of the
+ *
+ * License, or (at your option) any later version.
+ *
+ *
+ *
+ * This program is distributed in the hope that it will be useful,
+ *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *
+ * GNU Affero General Public License for more details.
+ *
+ *
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import RetroApi from '../api/retro_api';
+
+export default class Giphy {
+  static matcher = /\/giphy\s([^\s]+)/g;
+
+  constructor(retroId) {
+    this.retroId = retroId;
+  }
+
+  async isSupported() {
+    try {
+      if (this.supported === undefined) {
+        const [status] = await RetroApi.getRetroGif(this.retroId, 'supported');
+        this.supported = status === 200;
+      }
+    } catch {
+      this.supported = false;
+    }
+    return this.supported;
+  }
+
+  async interpolate(input) {
+    const matches = input.match(Giphy.matcher);
+    if (matches === null) {
+      return input;
+    }
+
+    if (!(await this.isSupported())) {
+      return input;
+    }
+
+    let temp = input;
+    const result = [];
+
+    // eslint-disable-next-line
+    for (const match of matches) {
+      // fetch the keyword for gif search
+      const keyword = encodeURI(match.replace('/giphy ', ''));
+
+      // find the substring to process and cut
+      const startIndex = temp.indexOf(match);
+      const endIndex = startIndex + match.length;
+
+      // force whole array to be await compatible
+      result.push(Promise.resolve(temp.substring(0, startIndex)));
+
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const response = await RetroApi.getRetroGif(this.retroId, keyword);
+        const {url} = response[1];
+        result.push(<img key={keyword} src={url} alt={keyword}/>);
+      } catch {
+        result.push(Promise.resolve(match));
+      }
+
+      // cut the processed string
+      temp = temp.substring(endIndex, temp.length);
+    }
+
+    result.push(Promise.resolve(temp));
+    return Promise.all(result);
+  }
+}

--- a/web/src/helpers/giphy.test.jsx
+++ b/web/src/helpers/giphy.test.jsx
@@ -1,0 +1,98 @@
+/*
+ * Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+ * remote teams.
+ *
+ * Copyright (C) 2016 - Present Pivotal Software, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ *
+ * it under the terms of the GNU Affero General Public License as
+ *
+ * published by the Free Software Foundation, either version 3 of the
+ *
+ * License, or (at your option) any later version.
+ *
+ *
+ *
+ * This program is distributed in the hope that it will be useful,
+ *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *
+ * GNU Affero General Public License for more details.
+ *
+ *
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import Giphy from './giphy';
+
+import '../spec_helper';
+
+describe('Giphy', () => {
+  let subject = null;
+  let fetchSpy = null;
+
+  beforeEach(() => {
+    subject = new Giphy('xyz-123');
+    fetchSpy = jest.spyOn(window, 'fetch');
+  });
+
+  it('isSupported should return false when not supported', async () => {
+    fetchSpy.mockRejectedValue(new Error('some error'));
+
+    expect(await subject.isSupported()).toEqual(false);
+  });
+
+  it('isSupported should return true when supported', async () => {
+    fetchSpy.mockResolvedValue({status: 200, json: () => ''});
+
+    expect(await subject.isSupported()).toEqual(true);
+  });
+
+  it('with no matches returns the original string', async () => {
+    expect(await subject.interpolate('xyz')).toEqual('xyz');
+  });
+
+  it('return an array with img elements replacing matches', async () => {
+    fetchSpy.mockResolvedValue({
+      status: 200,
+      json: () => ({url: 'http://example.com/gif'}),
+    });
+
+    const result = await subject.interpolate('abc /giphy def /giphy ghi jkl');
+
+    expect(result).toEqual([
+      'abc ',
+      <img key="def" src="http://example.com/gif" alt="def"/>,
+      ' ',
+      <img key="ghi" src="http://example.com/gif" alt="ghi"/>,
+      ' jkl',
+    ]);
+  });
+
+  it('returns the original match for any failed match replacements', async () => {
+    fetchSpy
+      .mockResolvedValueOnce({status: 200, json: () => ''})
+      .mockResolvedValueOnce({
+        status: 200,
+        json: () => ({url: 'http://example.com/gif'}),
+      })
+      .mockRejectedValueOnce(new Error('example'));
+
+    const result = await subject.interpolate('abc /giphy def /giphy ghi jkl');
+
+    expect(result).toEqual([
+      'abc ',
+      <img key="def" src="http://example.com/gif" alt="def"/>,
+      ' ',
+      '/giphy ghi',
+      ' jkl',
+    ]);
+  });
+});

--- a/web/src/stylesheets/_app.scss
+++ b/web/src/stylesheets/_app.scss
@@ -397,6 +397,10 @@ ol ol > li:before {
         width: 100%;
         text-align: left;
       }
+
+      img {
+        width: auto;
+      }
     }
 
     .item-vote {


### PR DESCRIPTION
Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Add giphy support to retro items - https://github.com/pivotal/postfacto/issues/106

* An explanation of the use cases your change solves

People can now add Gifs ...

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added
