### PR TITLE
Update email testing

### DIFF
--- a/api/config/environments/test.rb
+++ b/api/config/environments/test.rb
@@ -78,4 +78,13 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Configure Premailer with a strategy that just replaces stylesheets with nothing
+  module NoopPremailerStrategy
+    def self.load(*)
+      ''
+    end
+  end
+
+  Premailer::Rails.config.merge!(strategies: [NoopPremailerStrategy])
 end


### PR DESCRIPTION
Update to the `retros_request_spec.rb` to test the behaviour of the code (sending an email) rather than testing the implementation (that a service is called).  This change also highlighted that `premailer-rails` was downloading stylesheets from Google Fonts when an email was "sent" while running tests, which now should no longer be the case.

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added
