### PR TITLE
Update how we test RetrosChannel in request specs

### DIFF
--- a/api/app/controllers/retros_controller.rb
+++ b/api/app/controllers/retros_controller.rb
@@ -92,8 +92,14 @@ class RetrosController < ApplicationController
 
   def force_relogin_required?
     changes = @retro.previous_changes
-    changed_to_private = [false, true]
-    changes.key?(:is_private) && changes[:is_private] == changed_to_private
+
+    return false unless changes.key?(:is_private)
+
+    switched_from_public_to_private(*changes[:is_private])
+  end
+
+  def switched_from_public_to_private(was_private, is_now_private)
+    !was_private && is_now_private
   end
 
   def retro_errors_hash

--- a/api/app/models/item.rb
+++ b/api/app/models/item.rb
@@ -37,8 +37,7 @@ class Item < ActiveRecord::Base
   before_destroy :clear_highlight
 
   def vote!
-    Item.where(id: id).update_all('vote_count = vote_count + 1')
-    reload
+    increment! :vote_count
   end
 
   private

--- a/api/config/cable.yml
+++ b/api/config/cable.yml
@@ -32,7 +32,7 @@ development:
   adapter: async
 
 test:
-  adapter: async
+  adapter: test
 
 production:
   adapter: redis


### PR DESCRIPTION
Instead of mocking the class RetrosChannel in request specs, and exposing the inner workings of how the controllers are implemented, we can instead leverage `action-cable-testing` to validate that messages would be sent via ActionCable.  This can hopefully creates less brittle tests to allow refactoring in the future.

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added
