### PR TITLE
Remove auto generated video link

### DIFF
--- a/api/app/models/retro.rb
+++ b/api/app/models/retro.rb
@@ -38,8 +38,6 @@ class Retro < ActiveRecord::Base
   belongs_to :user
   enum item_order: { time: 'time', votes: 'votes' }
 
-  after_initialize :generate_video_link
-
   MAX_SLUG_LENGTH = 236
 
   friendly_id :generate_slug, use: :slugged
@@ -98,10 +96,5 @@ class Retro < ActiveRecord::Base
     end
 
     slug
-  end
-
-  def generate_video_link
-    self.video_link = video_link.presence ||
-                      'https://appear.in/retro-app-' + Array.new(8) { [*'0'..'9', *'a'..'z'].sample }.join
   end
 end

--- a/api/db/migrate/20190313150141_remove_null_contstraint_from_retros_video_link.rb
+++ b/api/db/migrate/20190313150141_remove_null_contstraint_from_retros_video_link.rb
@@ -1,0 +1,5 @@
+class RemoveNullContstraintFromRetrosVideoLink < ActiveRecord::Migration[5.2]
+  def change
+    change_column :retros, :video_link, :string, :null => true
+  end
+end

--- a/api/spec/model/retro_spec.rb
+++ b/api/spec/model/retro_spec.rb
@@ -34,10 +34,6 @@ describe Retro do
   describe '#initialize' do
     let(:retro) { Retro.create(name: 'My Retro') }
 
-    it 'should have a video link' do
-      expect(retro.video_link).to_not be_empty
-    end
-
     it 'should have a slug generated from the retro name' do
       expect(retro.slug).not_to eq 'my-retro'
       expect(retro.slug).to start_with 'my-retro'

--- a/api/spec/requests/retros_request_spec.rb
+++ b/api/spec/requests/retros_request_spec.rb
@@ -54,12 +54,6 @@ describe '/retros' do
                         as: :json
       end
 
-      it 'generates a unique video link' do
-        subject
-
-        assert_match(%r{^https://appear.in/retro-app-[0-9a-zA-Z]{8}$}, Retro.last.video_link)
-      end
-
       it 'returns the retro' do
         expect(response.status).to eq(201)
         data = JSON.parse(response.body)

--- a/e2e/spec/felicity_journey_spec.rb
+++ b/e2e/spec/felicity_journey_spec.rb
@@ -135,18 +135,6 @@ context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'tru
       end
     end
 
-    describe 'starting a retro' do
-      specify 'can open video call' do
-        retro_url = create_public_retro
-
-        visit retro_url
-        click_on 'VIDEO'
-
-        select_last_tab
-        expect(current_url).to include("https://appear.in/retro-app-")
-      end
-    end
-
     describe 'changing retro settings' do
       before do
         retro_url = create_public_retro('Settings Retro')
@@ -164,7 +152,7 @@ context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'tru
         expect(current_url).to end_with('/changed-url')
       end
 
-      specify 'can change video url' do
+      specify 'can add video url' do
         fill_in 'video_link', with: 'https://example.com'
         click_on 'Save changes'
 
@@ -173,20 +161,13 @@ context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'tru
         expect(current_url).to eq('https://example.com/')
       end
 
-      specify 'deleting video url defaults to appear in link' do
+      specify 'can remove video url' do
         fill_in 'video_link', with: ' '
-        # have to send backspace as filling with "" doesn't trigger change event
         find('#retro_video_link').send_keys(:backspace)
-
         click_on 'Save changes'
 
-        click_on 'VIDEO'
-
-        select_last_tab
-
-        expect(current_url).to include("https://appear.in/retro-app-")
+        expect(page).to_not have_content('VIDEO')
       end
-
     end
 
     describe 'archiving a retro' do
@@ -235,7 +216,7 @@ context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'tru
     end
   end
 
-  specify 'Auto facilitation journey' do
+  fspecify 'Auto facilitation journey' do
     register('felicity-auto-facilitate-user')
     create_public_retro
     retro_url = create_public_retro
@@ -259,7 +240,7 @@ context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'tru
 
     def send_right_key
       # Chrome web driver only allows sending key events on focusable elements, this button has a tabindex so is focusable
-      keyEventReciever = first('.retro-heading-button a')
+      keyEventReciever = first('.retro-item-add-input')
       keyEventReciever.native.send_keys(:right)
     end
 

--- a/e2e/spec/felicity_journey_spec.rb
+++ b/e2e/spec/felicity_journey_spec.rb
@@ -216,7 +216,7 @@ context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'tru
     end
   end
 
-  fspecify 'Auto facilitation journey' do
+  specify 'Auto facilitation journey' do
     register('felicity-auto-facilitate-user')
     create_public_retro
     retro_url = create_public_retro
@@ -240,7 +240,7 @@ context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'tru
 
     def send_right_key
       # Chrome web driver only allows sending key events on focusable elements, this button has a tabindex so is focusable
-      keyEventReciever = first('.retro-item-add-input')
+      keyEventReciever = first('a')
       keyEventReciever.native.send_keys(:right)
     end
 

--- a/web/src/components/retro-show/retro_heading.jsx
+++ b/web/src/components/retro-show/retro_heading.jsx
@@ -42,11 +42,6 @@ export default class RetroHeading extends React.Component {
     retroId: types.string.isRequired,
     archives: types.bool.isRequired,
     isMobile: types.bool.isRequired,
-    showVideoButton: types.bool,
-  };
-
-  static defaultProps = {
-    showVideoButton: false,
   };
 
   constructor(props) {
@@ -133,7 +128,7 @@ export default class RetroHeading extends React.Component {
   }
 
   render() {
-    const {retro, isMobile, showVideoButton} = this.props;
+    const {retro, isMobile} = this.props;
 
     return (
       <div className="retro-heading">
@@ -144,7 +139,7 @@ export default class RetroHeading extends React.Component {
           </div>
           <div className="retro-heading-buttons">
             {
-              showVideoButton ? (
+              retro.video_link ? (
                 <RaisedButton
                   className="retro-heading-button video-button"
                   backgroundColor="#2574a9"
@@ -155,6 +150,7 @@ export default class RetroHeading extends React.Component {
                 />
               ) : null
             }
+
             <RetroMenu isMobile={isMobile} items={this.getMenuItems()}/>
           </div>
         </span>

--- a/web/src/components/retro-show/retro_heading.test.jsx
+++ b/web/src/components/retro-show/retro_heading.test.jsx
@@ -97,6 +97,20 @@ describe('RetroHeading', () => {
         },
       });
     });
+
+    describe('when there is a video link', () => {
+      it('shows the video button', () => {
+        const dom = createShallowRetroHeading({video_link: 'http://the/video/link'});
+        expect(dom.find('.video-button')).toExist();
+      });
+    });
+
+    describe('when there is not a video link', () => {
+      it('hides the video button', () => {
+        const dom = createShallowRetroHeading({video_link: null});
+        expect(dom.find('.video-button')).not.toExist();
+      });
+    });
   });
 
   describe('viewing an archived retro', () => {

--- a/web/src/components/retro-show/show_retro_page.jsx
+++ b/web/src/components/retro-show/show_retro_page.jsx
@@ -338,7 +338,6 @@ export default class ShowRetroPage extends React.Component {
               retroId={retroId}
               isMobile={false}
               archives={archives}
-              showVideoButton={!archives}
             />
             <div className="retro-item-list">
               <RetroColumn


### PR DESCRIPTION
Appear.in seems to have removed its automagic links and now requires you to sign up. For now we'll just not show a video button when the user hasn't set a video link