### PR TITLE
Replace placeholders for app and system domain

### DIFF
--- a/deployment/INSTRUCTIONS.md
+++ b/deployment/INSTRUCTIONS.md
@@ -37,7 +37,7 @@ So you're ready to set Postfacto up, choose names for your web and API apps. We'
 1. Run the PCF deployment script from the `pcf` directory:
 
     ```bash
-    ./deploy.sh <web-app-name> <api-app-name> <pcf-url>
+    ./deploy.sh <web-app-name> <api-app-name> <cf-api-endpoint> <pcf-url>
     ```
 1. Log in to the admin dashboard (email: `email@example.com` and password: `password`) to check everything has worked at `api-app-name.{{pcf-url}}/admin`
 1. Create a retro for yourself by clicking on 'Retros' and the 'New Retro'
@@ -86,7 +86,7 @@ For deployments that do not want to setup Google OAuth, you will need to create 
    create a new project
 1. Go to APIs & Services > Credentials > Create Credentials > OAuth client ID > Web application
 1. Choose a name for your app
-1. In `Authorized JavaScript Origins`, set it to the public URL of your `web-app-name`.  For example: if deploying to PWS, your public URL will be `https://{{web-app-name}}.cfapps.io`
+1. In `Authorized JavaScript Origins`, set it to the public URL of your `web-app-name`. For example: if deploying to PWS, your public URL will be `https://{{web-app-name}}.{{pcf-url}}`
 1. You can leave redirect blank
 1. Take note of your `client-id` that is generated
 1. Add `"google_oauth_client_id": {{client-id}}` to the `config.js` for your installation.

--- a/deployment/deploy-cf.sh
+++ b/deployment/deploy-cf.sh
@@ -4,7 +4,8 @@ set -e
 
 WEB_HOST=$1
 API_HOST=$2
-CF_URL=${3:-https://api.run.pivotal.io}
+API_ENDPOINT=${3:-https://api.run.pivotal.io}
+APP_DOMAIN=${4:-cfapps.io}
 SESSION_TIME=${SESSION_TIME:-'""'}
 
 # The directory in which this script is located
@@ -12,11 +13,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ASSETS_DIR="$SCRIPT_DIR"/assets
 CONFIG_DIR="$SCRIPT_DIR"/config
 
-cf login -a $CF_URL
+cf login -a "${API_ENDPOINT}"
 
-cf push -f "$CONFIG_DIR"/manifest-api.yml -p "$ASSETS_DIR"/api --var api-app-name=$API_HOST --var web-app-name=$WEB_HOST --var pcf-url=$CF_URL --var session-time=$SESSION_TIME
+cf push -f "$CONFIG_DIR"/manifest-api.yml -p "$ASSETS_DIR"/api --var api-app-name=$API_HOST --var web-app-name=$WEB_HOST --var pcf-url=${APP_DOMAIN} --var session-time=$SESSION_TIME
 cf run-task $API_HOST 'ADMIN_EMAIL=email@example.com ADMIN_PASSWORD=password rake admin:create_user'
 
-sed -i '' "s/{{api-app-name}}/${API_HOST}/" "$CONFIG_DIR"/config.js
-cp "$CONFIG_DIR"/config.js "$ASSETS_DIR"/web
+sed \
+  -e "s/{{api-app-name}}/${API_HOST}/" \
+  -e "s/{{pcf-url}}/${APP_DOMAIN}/" \
+  <"$CONFIG_DIR"/config.js \
+  >"$ASSETS_DIR"/web/config.js
+
 cf push -f "$CONFIG_DIR"/manifest-web.yml -p "$ASSETS_DIR"/web --var api-app-name=$API_HOST --var web-app-name=$WEB_HOST

--- a/deployment/pws/config/config.js
+++ b/deployment/pws/config/config.js
@@ -5,8 +5,8 @@ window.Retro = {
     "scripts": ["application.js"],
     "stylesheets": ["application.css"],
     "useRevManifest": true,
-    "api_base_url": "https://{{api-app-name}}.cfapps.io",
-    "websocket_url": "wss://{{api-app-name}}.cfapps.io:4443/cable",
+    "api_base_url": "https://{{api-app-name}}.{{pcf-url}}",
+    "websocket_url": "wss://{{api-app-name}}.{{pcf-url}}:4443/cable",
     "contact": "",
     "terms": "",
     "privacy": ""

--- a/deployment/pws/config/manifest-api.yml
+++ b/deployment/pws/config/manifest-api.yml
@@ -9,6 +9,6 @@ applications:
     - postfacto-db
     - postfacto-redis
   env:
-    CLIENT_ORIGIN: https://((web-app-name)).cfapps.io
+    CLIENT_ORIGIN: https://((web-app-name)).((pcf-url))
     WEBSOCKET_PORT: 4443
     SESSION_TIME: ((session-time))

--- a/humans.txt
+++ b/humans.txt
@@ -37,3 +37,9 @@ Contact: matthew@el-chavez.me
 
 Engineer: Mike Stallard
 Contact: mikestallard@gmail.com
+
+Engineer: Steffen Uhlig
+Contact: Steffen.Uhlig@de.ibm.com
+
+Engineer: Matthias Diester
+Contact: matthias.diester@de.ibm.com


### PR DESCRIPTION
Introduce separation between system domain (API endpoint) and app domain. It
also replaces `{{pcf-url}}` in `deployment/pws/config/config.js` with provided
app domain.

Fixes #134.

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`. _Please note:_  The end to end tests all failed for a reason we could not find out.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
