### PR TITLE
Add color change to hover state of "thumbs up" and "edit pencil"

### DIFF
--- a/web/src/stylesheets/_app.scss
+++ b/web/src/stylesheets/_app.scss
@@ -742,6 +742,7 @@ button:focus {
   .item-edit, .item-done, .action-edit {
     :hover {
       cursor: pointer;
+      color: #2199e8;
     }
   }
 
@@ -786,6 +787,7 @@ button:focus {
 
     :hover {
       cursor: pointer;
+      color: #2199e8;
     }
 
     .item-vote-submit {


### PR DESCRIPTION
We find ourselves commonly clicking just outside of the click bounds because the cursor is always a "pointer" in the whole item. 

Having the color change specifically when you're over the actual click bounds should greatly reduce this pain.
The color that I picked matches the "video" and "menu" buttons found at the top right of the page and nicely fits with the theme as a whole.

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [ ] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
