### PR TITLE
Apply highlighting to edit/like icons on hover

### DIFF
--- a/web/src/stylesheets/_app.scss
+++ b/web/src/stylesheets/_app.scss
@@ -735,14 +735,15 @@ button:focus {
 
 .item-content, .action-content {
 
-  .item-edit, .item-done, .item-discussed, .action-edit {
-    text-align: right;
-  }
-
-  .item-edit, .item-done, .action-edit {
-    :hover {
+  .item-edit, .action-edit, .item-vote > .item-vote-submit {
+    &:hover {
+      color: $highlight;
       cursor: pointer;
     }
+  }
+
+  .item-edit, .item-done, .item-discussed, .action-edit {
+    text-align: right;
   }
 
   .item-text, .action-text {

--- a/web/src/stylesheets/_palette.scss
+++ b/web/src/stylesheets/_palette.scss
@@ -63,3 +63,5 @@ $button-red-hover: #F00000;
 $page-heading-background: #4BC1B1;
 
 $tile-hover: $happy;
+
+$highlight: #2199E8;


### PR DESCRIPTION
* A short explanation of the proposed change:

    The like heart icon and count and the edit pencil for retro items and actions are now highlighted in blue when you hover on their click area. 
* An explanation of the use cases your change solves

    This will hopefully reduce the incidence of people taking the wrong action on the items/actions (e.g. expanding the item when they actually wanted to "like" it).

* Links to any other associated PRs

    Supersedes #145 

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh` - [passing Travis build](https://travis-ci.org/textbook/postfacto/builds/557813622)

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added - N/A

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to) - already done
