### PR TITLE
Pin Ruby buildpacks - CF v1.7.40, Heroku v200 (fixes #147)

### DIFF
--- a/UPGRADES.md
+++ b/UPGRADES.md
@@ -2,7 +2,7 @@
 
 To update the version of Ruby used in Postfacto, the following steps need to be taken:
 
- 1. Update the `.tool-versions` file for anyone using [asdf-vm]
+ 1. Update the `.tool-versions` file for anyone using [asdf-vm][1]
 
  2. In `api/`, update `.ruby-version` and `Gemfile`, then run `bundle install` to update `Gemfile.lock`
 
@@ -25,10 +25,14 @@ To update the version of Ruby used in Postfacto, the following steps need to be 
 
  9. Publish the new image to Docker Hub - this needs to happen *before* the Travis build can complete
 
- 10. Update the pinned buildpacks in `deployment/{pcf,pws}/config/manifest-api.yml`, according to the latest [release]
-    that supports the selected version
+ 10. Update the pinned buildpacks in `deployment/{pcf,pws}/config/manifest-api.yml`, according to the latest
+    [release][2] that supports the selected version
 
- 11. You can now commit and push and make sure everything passes in Travis
+ 11. Update the pinned buildpacks in `deployment/{deploy,upgrade}-heroku.sh`, according to the latest [release][3] that
+    supports the selected version
 
-  [asdf-vm]: https://asdf-vm.com/#/
-  [release]: https://github.com/cloudfoundry/ruby-buildpack/releases
+ 12. You can now commit and push and make sure everything passes in Travis
+
+  [1]: https://asdf-vm.com/#/
+  [2]: https://github.com/cloudfoundry/ruby-buildpack/releases
+  [3]: https://github.com/heroku/heroku-buildpack-ruby/blob/master/CHANGELOG.md

--- a/deployment/deploy-heroku.sh
+++ b/deployment/deploy-heroku.sh
@@ -53,7 +53,7 @@ CONFIG_DIR="$SCRIPT_DIR"/config
 ###################
 
 pushd "$ASSETS_DIR"/api
-heroku create ${API_HOST} --buildpack heroku/ruby
+heroku create ${API_HOST} --buildpack https://github.com/heroku/heroku-buildpack-ruby.git#v200
 heroku addons:create heroku-postgresql:hobby-dev -a ${API_HOST}
 heroku addons:create heroku-redis:hobby-dev -a ${API_HOST}
 heroku config:set WEBSOCKET_PORT=4443 CLIENT_ORIGIN=https://${WEB_HOST}.herokuapp.com SESSION_TIME=${SESSION_TIME} -a ${API_HOST}

--- a/deployment/pcf/config/manifest-api.yml
+++ b/deployment/pcf/config/manifest-api.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((api-app-name))
   instances: 2
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.41
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.40
   memory: 256M
   command: bundle exec rake db:migrate && bundle exec rails s -p $PORT -e $RAILS_ENV
   services:

--- a/deployment/pws/config/manifest-api.yml
+++ b/deployment/pws/config/manifest-api.yml
@@ -2,7 +2,7 @@
 applications:
 - name: ((api-app-name))
   instances: 2
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.41
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.40
   memory: 256M
   command: bundle exec rake db:migrate && bundle exec rails s -p $PORT -e $RAILS_ENV
   services:

--- a/deployment/upgrade-heroku.sh
+++ b/deployment/upgrade-heroku.sh
@@ -61,6 +61,7 @@ fi
 ###################
 
 pushd "$ASSETS_DIR"/api
+heroku buildpacks:set -a ${API_HOST} https://github.com/heroku/heroku-buildpack-ruby.git#v200
 
 rm -rf .git # blow away any existent git directory from a previous run
 git init .


### PR DESCRIPTION
* A short explanation of the proposed change:

    Switch the pinned Ruby buildpack for CF deployments to [v1.7.40](https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.7.40) and the Ruby buildpack for Heroku deployments to [v200](https://github.com/heroku/heroku-buildpack-ruby/blob/master/CHANGELOG.md#v200-372019)

* An explanation of the use cases your change solves

    Fixes error on deployment caused by mismatched versions of bundler - #147 

* Links to any other associated PRs

    N/A

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh` - no change to code, I tested the deployments to Heroku and PCFOne manually

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added - N/A

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to) - already done
