### PR TITLE
Normalize Redis password from VCAP (fixes #153)

### DIFF
--- a/api/lib/configurations/redis_configuration_provider.rb
+++ b/api/lib/configurations/redis_configuration_provider.rb
@@ -38,7 +38,12 @@ class RedisConfigurationProvider
     unless ENV['VCAP_SERVICES'].nil?
       c = CF::App::Credentials.find_by_service_tag('redis')
       host = c['hostname'] || c.fetch('host')
-      Addressable::URI.new(scheme: 'redis', host: host, password: c['password'], port: c.fetch('port')).to_s
+      Addressable::URI.new(
+        scheme: 'redis',
+        host: host,
+        password: c['password'],
+        port: c.fetch('port')
+      ).normalize.to_s
     end
   end
 end

--- a/api/spec/lib/redis_configuration_provider_spec.rb
+++ b/api/spec/lib/redis_configuration_provider_spec.rb
@@ -65,7 +65,7 @@ describe RedisConfigurationProvider do
                   'tags' => 'redis',
                   'credentials' => {
                     'hostname' => 'hostname',
-                    'password' => 'pass',
+                    'password' => 'irrelevant',
                     'port' => 234
                   }
                 }
@@ -90,7 +90,7 @@ describe RedisConfigurationProvider do
         let(:redis_url) { nil }
 
         context 'when VCAP_SERVICES is defined in the environment' do
-          context 'and host is declared as host' do
+          context 'and host is declared as hostname' do
             let(:vcap_services) do
               {
                 'redis' => [
@@ -111,7 +111,7 @@ describe RedisConfigurationProvider do
             end
           end
 
-          context 'and host is declared as hostname' do
+          context 'and host is declared as host' do
             let(:vcap_services) do
               {
                 'redis' => [
@@ -129,6 +129,27 @@ describe RedisConfigurationProvider do
 
             it 'builds a URL based upon the redis service described by vcap services' do
               expect(subject.redis_config).to eq('redis://:pass@host:234')
+            end
+          end
+
+          context 'and the password contains special characters' do
+            let(:vcap_services) do
+              {
+                'redis' => [
+                  {
+                    'tags' => 'redis',
+                    'credentials' => {
+                      'hostname' => 'hostname',
+                      'password' => 'pass/wo=d',
+                      'port' => 234
+                    }
+                  }
+                ]
+              }.to_json
+            end
+
+            it 'builds a URL based upon the redis service described by vcap services' do
+              expect(subject.redis_config).to eq('redis://:pass%2Fwo%3Dd@hostname:234')
             end
           end
         end


### PR DESCRIPTION
* A short explanation of the proposed change:

    Normalize password from VCAP_SERVICES when building the Redis URL

* An explanation of the use cases your change solves

    Fixes #153 

* Links to any other associated PRs

    Pulled out of #152

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh` - [passing Travis build](https://travis-ci.org/textbook/postfacto/builds/559914595), also tested deployment to PWS via the deploy script and subsequent successful connection to Redis

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
