### PR TITLE
Fix deprecated buildpack manifest key

### DIFF
--- a/deployment/pcf/config/manifest-api.yml
+++ b/deployment/pcf/config/manifest-api.yml
@@ -2,7 +2,8 @@
 applications:
 - name: ((api-app-name))
   instances: 2
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.40
+  buildpacks:
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.40
   memory: 256M
   command: bundle exec rake db:migrate && bundle exec rails s -p $PORT -e $RAILS_ENV
   services:

--- a/deployment/pws/config/manifest-api.yml
+++ b/deployment/pws/config/manifest-api.yml
@@ -2,7 +2,8 @@
 applications:
 - name: ((api-app-name))
   instances: 2
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.40
+  buildpacks:
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.40
   memory: 256M
   command: bundle exec rake db:migrate && bundle exec rails s -p $PORT -e $RAILS_ENV
   services:

--- a/humans.txt
+++ b/humans.txt
@@ -46,3 +46,6 @@ Contact: matthias.diester@de.ibm.com
 
 Engineer: Callum Stott
 Contact: callum@seadowg.com
+
+Engineer: Mike Kenyon
+Contact: mike.kenyon@gmail.com


### PR DESCRIPTION
The singular `buildpack` key is deprecated. It has been replaced by the
`buildpacks` array, supporting multiple buildpacks!

https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#deprecated

Authored-by: Mike Kenyon <mike.kenyon@gmail.com>
             Former CAPI and CF-CLI team member <3

Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
