### PR TITLE
Exclude some fields from retro channel payload

### DIFF
--- a/api/app/channels/retros_channel.rb
+++ b/api/app/channels/retros_channel.rb
@@ -36,7 +36,10 @@ require 'security/auth_token'
 class RetrosChannel < ApplicationCable::Channel
 
   def self.broadcast(retro)
-    broadcast_to retro, retro: retro.as_json(include: {items: {}, action_items: {}, archives: {only: :id}})
+    broadcast_to retro, retro: retro.as_json(
+      except: [:encrypted_password, :salt],
+      include: {items: {}, action_items: {}, archives: {only: :id}},
+    )
   end
 
   def self.broadcast_force_relogin(retro, originator_id)

--- a/api/spec/channels/retros_channel_spec.rb
+++ b/api/spec/channels/retros_channel_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe RetrosChannel, type: :channel do
           expect(subscription).to be_confirmed
         end
       end
+
+      it 'does not broadcast the encrypted password or salt' do
+        expect {
+          RetrosChannel.broadcast(retro)
+        }.to have_broadcasted_to(retro).with { |payload|
+          expect(payload['retro']).not_to include 'encrypted_password'
+          expect(payload['retro']).not_to include 'salt'
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
Encrypted password and salt aren't required from front-end functionality.

* A short explanation of the proposed change:

    Exclude `encrypted_password` and `salt` fields from the retro that's sent over the websocket

* An explanation of the use cases your change solves

    Simplifies the data available to the frontend and avoids leaking internal implementation details

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh` - [passing Travis build](https://travis-ci.org/textbook/postfacto/builds/562515971)

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
