### PR TITLE
Make the CLIENT_ORIGIN optional

### DIFF
--- a/api/config/environments/production.rb
+++ b/api/config/environments/production.rb
@@ -121,10 +121,12 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.middleware.insert_before 0, Rack::Cors do
-    allow do
-      origins ENV['CLIENT_ORIGIN']
-      resource '*', headers: :any, methods: [:get, :post, :options, :patch, :delete, :put]
+  if ENV['CLIENT_ORIGIN'].present?
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins ENV['CLIENT_ORIGIN']
+        resource '*', headers: :any, methods: [:get, :post, :options, :patch, :delete, :put]
+      end
     end
   end
 end

--- a/api/lib/configurations/action_cable_configuration_provider.rb
+++ b/api/lib/configurations/action_cable_configuration_provider.rb
@@ -62,7 +62,7 @@ require_relative 'action_cable_configuration'
 class ActionCableConfigurationProvider
   def config(host:)
     url = "wss://#{host}:#{ENV['WEBSOCKET_PORT'] || 443}/cable"
-    allowed_request_origins = ["https://#{host}", ENV['CLIENT_ORIGIN']]
+    allowed_request_origins = ["https://#{host}", ENV['CLIENT_ORIGIN']].compact
 
     ActionCableConfiguration.new(url, allowed_request_origins)
   end

--- a/api/spec/lib/action_cable_configuration_provider_spec.rb
+++ b/api/spec/lib/action_cable_configuration_provider_spec.rb
@@ -64,4 +64,14 @@ describe ActionCableConfigurationProvider do
       end
     end
   end
+
+  context 'when CLIENT_ORIGIN is NOT set in the environment' do
+    let(:client_origin) { nil }
+
+    it 'does not include an empty allowed request origin' do
+      configuration = subject.config(host: 'fixture-host')
+
+      expect(configuration.allowed_request_origins).to eq(['https://fixture-host'])
+    end
+  end
 end


### PR DESCRIPTION
This paves the way for alternate deployment topologies, e.g. single
artifact or path routing.

Thanks for contributing to Postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

   Update the configuration to allow the app to start if the `CLIENT_ORIGIN` env var isn't set

* An explanation of the use cases your change solves

    Allows use in scenarios where this setting isn't required, for example serving the client from the Rails app or using path-based routing in CF.

* Links to any other associated PRs

    Part of cutting #152 into smaller slices

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
