### PR TITLE
Handle paths in VCAP URIs

### DIFF
--- a/api/lib/configurations/action_cable_host_provider.rb
+++ b/api/lib/configurations/action_cable_host_provider.rb
@@ -28,10 +28,16 @@
 #
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+require 'uri'
+
 class ActionCableHostProvider
   def host
     return ENV['ACTION_CABLE_HOST'] unless ENV['ACTION_CABLE_HOST'].nil?
 
-    JSON.parse(ENV['VCAP_APPLICATION']).fetch('uris')[0] unless ENV['VCAP_APPLICATION'].nil?
+    unless ENV['VCAP_APPLICATION'].nil?
+      uri = JSON.parse(ENV['VCAP_APPLICATION']).fetch('uris')[0]
+      uri = "//#{uri}" if URI(uri).scheme.nil?
+      URI.parse(uri).host
+    end
   end
 end

--- a/api/spec/lib/action_cable_host_provider_spec.rb
+++ b/api/spec/lib/action_cable_host_provider_spec.rb
@@ -66,10 +66,20 @@ describe ActionCableHostProvider do
       let(:action_cable_host) { nil }
 
       context 'when VCAP_APPLICATION is set in the environment' do
-        let(:vcap_application) { { 'uris' => ['vcap-uri-a', 'vcap-uri-b'] }.to_json }
+        context 'and URIs do not contain a path' do
+          let(:vcap_application) { { 'uris' => ['vcap-uri-a', 'vcap-uri-b'] }.to_json }
 
-        it "returns the first hostname from VCAP_APPLICATION's uris" do
-          expect(subject.host).to eq('vcap-uri-a')
+          it "returns the first hostname from VCAP_APPLICATION's uris" do
+            expect(subject.host).to eq('vcap-uri-a')
+          end
+        end
+
+        context 'and the URIs do contain a path' do
+          let(:vcap_application) { { 'uris' => ['vcap-uri-a.example.com/some-cool-path'] }.to_json }
+
+          it "returns the first hostname from VCAP_APPLICATION's uris with the path stripped out" do
+            expect(subject.host).to eq('vcap-uri-a.example.com')
+          end
         end
       end
 


### PR DESCRIPTION
* A short explanation of the proposed change:

    Strip the path from a URI supplied via VCAP_APPLICATION

* An explanation of the use cases your change solves

    Allows mounting the Rails app on a path route in CF

* Links to any other associated PRs

    Part of cutting #152 into smaller slices

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
