### PR TITLE
Fix retro item input boxes remaining multiline after submit

### DIFF
--- a/web/src/components/retro-show/retro_column_input.jsx
+++ b/web/src/components/retro-show/retro_column_input.jsx
@@ -34,6 +34,10 @@ import types from 'prop-types';
 import TextareaAutosize from 'react-autosize-textarea';
 import EmojiSelector from './emoji_selector';
 
+function inputHasContent(target) {
+  return target.value.trim().length !== 0;
+}
+
 export default class RetroColumnInput extends React.Component {
     static propTypes = {
       category: types.string.isRequired,
@@ -93,7 +97,7 @@ export default class RetroColumnInput extends React.Component {
     }
 
     onChange(event) {
-      if (event.target.value.trim().length === 0) {
+      if (!inputHasContent(event.target)) {
         this.setState({multiline: ''});
       }
 
@@ -102,7 +106,9 @@ export default class RetroColumnInput extends React.Component {
 
     onResize(event) {
       // store value as well to work around https://github.com/buildo/react-autosize-textarea/issues/109
-      this.setState({multiline: 'multiline', inputText: event.target.value});
+
+      const multiline = inputHasContent(event.target) ? 'multiline' : '';
+      this.setState({multiline, inputText: event.target.value});
     }
 
     inputFocus() {

--- a/web/src/components/retro-show/retro_column_input.test.jsx
+++ b/web/src/components/retro-show/retro_column_input.test.jsx
@@ -167,6 +167,16 @@ describe('inputting an action item', () => {
     expect(subject.find('.input-button-wrapper')).toHaveClassName('multiline');
   });
 
+  it('removes multiline after resizing after submit', () => {
+    const event = {target: {value: ''}};
+
+    subject.find(TextareaAutosize).prop('onResize')(event);
+    subject.update();
+
+    expect(subject.find('.input-box')).not.toHaveClassName('multiline');
+    expect(subject.find('.input-button-wrapper')).not.toHaveClassName('multiline');
+  });
+
   it('shows the emoji button on button click', () => {
     expect(subject.find(EmojiSelector)).not.toExist();
 


### PR DESCRIPTION
* A short explanation of the proposed change:

This fixes #169 which was happening due to a workaround that was overzealous on setting `multiline` on the input after submit.

* An explanation of the use cases your change solves

The box not resizing after submitting a retro item.

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added