### PR TITLE
Upgrade foundation sites

### DIFF
--- a/e2e/spec/felicity_journey_spec.rb
+++ b/e2e/spec/felicity_journey_spec.rb
@@ -404,15 +404,15 @@ context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'tru
     find('div.retro-item', text: 'this is a happy item').click
 
     # Done an item
-    within('div.retro-item', text: 'this is a happy item') do
+    sleep(1)
+    within('div.retro-item.highlight', text: 'this is a happy item') do
       expect(page).to have_css('.item-done')
       find('.item-done').click
     end
 
     expect(page).not_to have_css '.highlight'
-    expect(page).not_to have_css('.retro-item-timer-clock')
+    expect(page).not_to have_css '.retro-item-timer-clock'
 
-    expect(page).to have_css('div.retro-item.discussed .item-text', text: 'this is a happy item')
     within(find('div.retro-item.discussed', text: 'this is a happy item')) do
       expect(page).to have_css('.item-discussed')
       expect(page).to_not have_css('.item-delete')

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3287,7 +3287,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3305,11 +3306,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3322,15 +3325,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3433,7 +3439,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3443,6 +3450,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3455,17 +3463,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3482,6 +3493,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3554,7 +3566,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3564,6 +3577,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3639,7 +3653,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3669,6 +3684,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3686,6 +3702,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3724,11 +3741,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -6309,13 +6328,9 @@
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "foundation-sites": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.2.4.tgz",
-      "integrity": "sha1-VUdGyfPVBb1WRrTcwD+KmUHmf3s=",
-      "requires": {
-        "jquery": "^2.2.0",
-        "what-input": "^2.0.0"
-      }
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.5.3.tgz",
+      "integrity": "sha512-ZwI0idjHHjezh6jRjpPxkczvmtUuJ1uGatZHpyloX0MvsFHfM0BFoxrqdXryXugGPdmb+yJi3JYMnz6+5t3K1A=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -8061,7 +8076,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -8079,11 +8095,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -8096,15 +8114,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -8207,7 +8228,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -8217,6 +8239,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -8229,17 +8252,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -8256,6 +8282,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -8328,7 +8355,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -8338,6 +8366,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -8413,7 +8442,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8443,6 +8473,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8460,6 +8491,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8498,11 +8530,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }
@@ -9245,11 +9279,6 @@
           }
         }
       }
-    },
-    "jquery": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
-      "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
     },
     "js-base64": {
       "version": "2.5.1",
@@ -15195,11 +15224,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
-    },
-    "what-input": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/what-input/-/what-input-2.1.1.tgz",
-      "integrity": "sha1-hrbgM41nCp/ZNokrj1EVxP4NHQs="
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "actioncable": "^5.2.2",
-    "foundation-sites": "6.2.4",
+    "foundation-sites": "6.5.3",
     "grapnel": "^0.7.0",
     "material-ui": "^0.20.2",
     "mixpanel-browser": "^2.26.0",

--- a/web/src/stylesheets/_app.scss
+++ b/web/src/stylesheets/_app.scss
@@ -55,7 +55,7 @@
 @include foundation-drilldown-menu;
 @include foundation-dropdown;
 @include foundation-dropdown-menu;
-@include foundation-flex-video;
+@include foundation-responsive-embed;
 @include foundation-label;
 @include foundation-media-object;
 @include foundation-off-canvas;
@@ -171,7 +171,7 @@ ol ol > li:before {
     }
 
     .video-box {
-      @extend .flex-video;
+      @extend .responsive-embed;
 
       @include breakpoint(large) {
         flex: 1;
@@ -425,7 +425,7 @@ ol ol > li:before {
   background-color: $page-heading-background;
   height: 100%;
 
-  @media #{$small-only} {
+  @include breakpoint(small only) {
     display: none;
   }
 }

--- a/web/src/stylesheets/_app.scss
+++ b/web/src/stylesheets/_app.scss
@@ -753,6 +753,7 @@ button:focus {
     white-space: pre-line;
 
     button {
+      font-weight: inherit;
       line-height: 1.1;
     }
 

--- a/web/src/stylesheets/_settings.scss
+++ b/web/src/stylesheets/_settings.scss
@@ -81,6 +81,7 @@
 $global-font-size: 100%;
 $global-width: rem-calc(1200);
 $global-lineheight: 1.5;
+$global-color-pick-contrast-tolerance: 0.1;
 $foundation-palette: (
         primary: #2199e8,
         secondary: #777,
@@ -140,22 +141,22 @@ $header-font-family: 'Montserrat', Roboto, Arial, sans-serif;
 $header-font-weight: $global-weight-normal;
 $header-font-style: normal;
 $font-family-monospace: Consolas, 'Liberation Mono', Courier, monospace;
-$header-sizes: (
+$header-styles: (
         small: (
-                'h1': 24,
-                'h2': 20,
-                'h3': 19,
-                'h4': 18,
-                'h5': 17,
-                'h6': 16,
+                'h1': ('font-size': 24),
+                'h2': ('font-size': 20),
+                'h3': ('font-size': 19),
+                'h4': ('font-size': 18),
+                'h5': ('font-size': 17),
+                'h6': ('font-size': 16),
         ),
         medium: (
-                'h1': 28,
-                'h2': 28,
-                'h3': 28,
-                'h4': 25,
-                'h5': 20,
-                'h6': 16,
+                'h1': ('font-size': 28),
+                'h2': ('font-size': 28),
+                'h3': ('font-size': 28),
+                'h4': ('font-size': 25),
+                'h5': ('font-size': 20),
+                'h6': ('font-size': 16),
         ),
 );
 $header-color: inherit;
@@ -229,12 +230,12 @@ $input-error-font-weight: $global-weight-bold;
 
 $accordion-background: $white;
 $accordion-plusminus: true;
-$accordion-item-color: foreground($accordion-background, $primary-color);
+$accordion-item-color: color-pick-contrast($accordion-background, ($primary-color, $white));
 $accordion-item-background-hover: $light-gray;
 $accordion-item-padding: 1.25rem 1rem;
 $accordion-content-background: $white;
 $accordion-content-border: 1px solid $light-gray;
-$accordion-content-color: foreground($accordion-background, $primary-color);
+$accordion-content-color: color-pick-contrast($accordion-background, ($primary-color, $white));
 $accordion-content-padding: 1rem;
 
 // 8. Accordion Menu
@@ -248,7 +249,7 @@ $accordionmenu-arrow-color: $primary-color;
 
 $badge-palette: $foundation-palette;
 $badge-background: $primary-color;
-$badge-color: foreground($badge-background);
+$badge-color: color-pick-contrast($badge-background);
 $badge-padding: 0.3em;
 $badge-minwidth: 2.1em;
 $badge-font-size: 0.6rem;
@@ -431,7 +432,7 @@ $meter-fill-bad: $alert-color;
 // 24. Off-canvas
 // --------------
 
-$offcanvas-size: 250px;
+$offcanvas-sizes: ('small': 250px);
 $offcanvas-background: $light-gray;
 $offcanvas-zindex: -1;
 $offcanvas-transition-length: 0.5s;
@@ -467,7 +468,7 @@ $pagination-item-spacing: rem-calc(1);
 $pagination-radius: $global-radius;
 $pagination-item-background-hover: $light-gray;
 $pagination-item-background-current: $primary-color;
-$pagination-item-color-current: foreground($pagination-item-background-current);
+$pagination-item-color-current: color-pick-contrast($pagination-item-background-current);
 $pagination-item-color-disabled: $medium-gray;
 $pagination-ellipsis-color: $black;
 $pagination-mobile-items: false;
@@ -553,7 +554,7 @@ $tab-item-padding: 1.25rem 1.5rem;
 $tab-expand-max: 6;
 $tab-content-background: $white;
 $tab-content-border: $light-gray;
-$tab-content-color: foreground($tab-background, $primary-color);
+$tab-content-color: color-pick-contrast($tab-background, ($primary-color, $white));
 $tab-content-padding: 1rem;
 
 // 33. Thumbnail


### PR DESCRIPTION
* A short explanation of the proposed change:

    Upgrade foundation-sites to latest (6.5.3)

     - Fix issues relating to API changes in the upgrade
     - Add a sleep to avoid a timing issue in the E2E test

* An explanation of the use cases your change solves

    Removes lodash vulnerability that came from an older version used in foundation-sites

* Links to any other associated PRs

    Fixes last remaining JS vulnerabilities after #166

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
