### PR TITLE
Update deploy and upgrade scripts to work on Unix

### DIFF
--- a/deployment/deploy-heroku.sh
+++ b/deployment/deploy-heroku.sh
@@ -53,32 +53,34 @@ CONFIG_DIR="$SCRIPT_DIR"/config
 ###################
 
 pushd "$ASSETS_DIR"/api
-heroku create ${API_HOST} --buildpack https://github.com/heroku/heroku-buildpack-ruby.git#v200
-heroku addons:create heroku-postgresql:hobby-dev -a ${API_HOST}
-heroku addons:create heroku-redis:hobby-dev -a ${API_HOST}
-heroku config:set WEBSOCKET_PORT=4443 CLIENT_ORIGIN=https://${WEB_HOST}.herokuapp.com SESSION_TIME=${SESSION_TIME} -a ${API_HOST}
+  heroku create ${API_HOST} --buildpack https://github.com/heroku/heroku-buildpack-ruby.git#v200
+  heroku addons:create heroku-postgresql:hobby-dev -a ${API_HOST}
+  heroku addons:create heroku-redis:hobby-dev -a ${API_HOST}
+  heroku config:set WEBSOCKET_PORT=4443 CLIENT_ORIGIN=https://${WEB_HOST}.herokuapp.com SESSION_TIME=${SESSION_TIME} -a ${API_HOST}
 
-rm -rf .git # blow away any existent git directory from a previous run
-git init .
-git add .
-git commit -m "Packaging for initial Heroku deployment"
-git push --set-upstream https://git.heroku.com/${API_HOST}.git master
-heroku run rake admin:create_user ADMIN_EMAIL=email@example.com ADMIN_PASSWORD=password -a ${API_HOST}
+  rm -rf .git # blow away any existent git directory from a previous run
+  git init .
+  git add .
+  git commit -m "Packaging for initial Heroku deployment"
+  git push --set-upstream https://git.heroku.com/${API_HOST}.git master
+  heroku run rake admin:create_user ADMIN_EMAIL=email@example.com ADMIN_PASSWORD=password -a ${API_HOST}
 popd
 
 ###########################
 # Deploy the web frontend
 ###########################
 
-cp "$CONFIG_DIR"/config.js "$ASSETS_DIR"/web/public_html
 pushd "$ASSETS_DIR"/web
-sed -i '' "s/{{api-app-name}}/${API_HOST}/" public_html/config.js
+  sed \
+    -e "s/{{api-app-name}}/${API_HOST}/" \
+    <"$CONFIG_DIR"/config.js \
+    >"$ASSETS_DIR"/web/public_html/config.js
 
-heroku create ${WEB_HOST} --buildpack https://github.com/heroku/heroku-buildpack-static
+  heroku create ${WEB_HOST} --buildpack https://github.com/heroku/heroku-buildpack-static
 
-rm -rf .git # blow away any existent git directory from a previous run
-git init .
-git add .
-git commit -m "Packaging for initial Heroku deployment"
-git push --set-upstream https://git.heroku.com/${WEB_HOST}.git master
+  rm -rf .git # blow away any existent git directory from a previous run
+  git init .
+  git add .
+  git commit -m "Packaging for initial Heroku deployment"
+  git push --set-upstream https://git.heroku.com/${WEB_HOST}.git master
 popd

--- a/deployment/upgrade-cf.sh
+++ b/deployment/upgrade-cf.sh
@@ -4,7 +4,8 @@ set -e
 
 WEB_HOST=$1
 API_HOST=$2
-CF_URL=${3:-https://api.run.pivotal.io}
+API_ENDPOINT=${3:-https://api.run.pivotal.io}
+APP_DOMAIN=${4:-cfapps.io}
 SESSION_TIME=${SESSION_TIME:-'""'}
 
 # The directory in which this script is located
@@ -12,10 +13,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ASSETS_DIR="$SCRIPT_DIR"/assets
 CONFIG_DIR="$SCRIPT_DIR"/config
 
-cf login -a $CF_URL
+cf login -a $API_ENDPOINT
 
 cf push -f "$CONFIG_DIR"/manifest-api.yml -p "$ASSETS_DIR"/api --var api-app-name=$API_HOST --var web-app-name=$WEB_HOST --var pcf-url=$CF_URL --var session-time=$SESSION_TIME
 
-sed -i '' "s/{{api-app-name}}/${API_HOST}/" "$CONFIG_DIR"/config.js
-cp "$CONFIG_DIR"/config.js "$ASSETS_DIR"/web
+sed \
+  -e "s/{{api-app-name}}/${API_HOST}/" \
+  -e "s/{{pcf-url}}/${APP_DOMAIN}/" \
+  <"$CONFIG_DIR"/config.js \
+  >"$ASSETS_DIR"/web/config.js
+
 cf push -f "$CONFIG_DIR"/manifest-web.yml -p "$ASSETS_DIR"/web --var api-app-name=$API_HOST --var web-app-name=$WEB_HOST

--- a/deployment/upgrade-heroku.sh
+++ b/deployment/upgrade-heroku.sh
@@ -61,26 +61,28 @@ fi
 ###################
 
 pushd "$ASSETS_DIR"/api
-heroku buildpacks:set -a ${API_HOST} https://github.com/heroku/heroku-buildpack-ruby.git#v200
+  heroku buildpacks:set -a ${API_HOST} https://github.com/heroku/heroku-buildpack-ruby.git#v200
 
-rm -rf .git # blow away any existent git directory from a previous run
-git init .
-git add .
-git commit -m "Packaging for Heroku upgrade"
-git push --force --set-upstream https://git.heroku.com/${API_HOST}.git master
+  rm -rf .git # blow away any existent git directory from a previous run
+  git init .
+  git add .
+  git commit -m "Packaging for Heroku upgrade"
+  git push --force --set-upstream https://git.heroku.com/${API_HOST}.git master
 popd
 
 ###########################
 # Upgrade the web frontend
 ###########################
 
-cp "$CONFIG_DIR"/config.js "$ASSETS_DIR"/web/public_html
 pushd "$ASSETS_DIR"/web
-sed -i '' "s/{{api-app-name}}/${API_HOST}/" public_html/config.js
+  sed \
+    -e "s/{{api-app-name}}/${API_HOST}/" \
+    <"$CONFIG_DIR"/config.js \
+    >"$ASSETS_DIR"/web/public_html/config.js
 
-rm -rf .git # blow away any existent git directory from a previous run
-git init .
-git add .
-git commit -m "Packaging for Heroku upgrade"
-git push --force --set-upstream https://git.heroku.com/${WEB_HOST}.git master
+  rm -rf .git # blow away any existent git directory from a previous run
+  git init .
+  git add .
+  git commit -m "Packaging for Heroku upgrade"
+  git push --force --set-upstream https://git.heroku.com/${WEB_HOST}.git master
 popd

--- a/deployment/upgrade-heroku.sh
+++ b/deployment/upgrade-heroku.sh
@@ -61,8 +61,10 @@ fi
 ###################
 
 pushd "$ASSETS_DIR"/api
-  heroku buildpacks:set -a ${API_HOST} https://github.com/heroku/heroku-buildpack-ruby.git#v200
-
+  BUILDPACK='https://github.com/heroku/heroku-buildpack-ruby.git#v200'
+  if [[ ! $(heroku buildpacks -a ${API_HOST}) =~ ${BUILDPACK} ]]; then
+    heroku buildpacks:set -a ${API_HOST} ${BUILDPACK}
+  fi
   rm -rf .git # blow away any existent git directory from a previous run
   git init .
   git add .


### PR DESCRIPTION
* A short explanation of the proposed change:

    - Use sed in a cross-platform compatible manner
    - Check buildpack before trying to set it in Heroku upgrade (you've got to check yourself before you wreck yourself)

* An explanation of the use cases your change solves

    Allows the package to be deployed from non-macOS *nix systems. Fixes remainder of issues reported in #133 

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
