### PR TITLE
Specify nodejs version

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -41,6 +41,9 @@
   "eslintConfig": {
     "extends": "react-app"
   },
+  "engines": {
+    "node":"~>10.15.0"
+  },
   "browserslist": [
     ">0.2%",
     "not dead",

--- a/web/package.json
+++ b/web/package.json
@@ -42,7 +42,7 @@
     "extends": "react-app"
   },
   "engines": {
-    "node":"~>10.15.0"
+    "node": "^12.6.0"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
* A short explanation of the proposed change:
Specify NodeJS version for the application. API has the version specified

* An explanation of the use cases your change solves
The default version of NodeJS(v6) in our installation does not work with Postfacto.

* Links to any other associated PRs

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [ ] I have run all the tests using `./test.sh`.
I have deployed the version.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added
No new files added

* [ ] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
Next time