### PR TITLE
Fix missing var in CF upgrade script and remove login

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -37,7 +37,7 @@ So you're ready to set Postfacto up, choose names for your web and API apps. We'
 1. Run the PCF deployment script from the `pcf` directory:
 
     ```bash
-    ./deploy.sh <web-app-name> <api-app-name> <cf-api-endpoint> <pcf-url>
+    ./deploy.sh <web-app-name> <api-app-name> <pcf-url>
     ```
 1. Log in to the admin dashboard (email: `email@example.com` and password: `password`) to check everything has worked at `api-app-name.{{pcf-url}}/admin`
 1. Create a retro for yourself by clicking on 'Retros' and the 'New Retro'
@@ -48,7 +48,7 @@ So you're ready to set Postfacto up, choose names for your web and API apps. We'
 
 1. Presuming the steps in the Initial deployment section have been completed, run the upgrade script from the `pcf` directory:
   ```bash
-  ./upgrade.sh <web-app-name> <api-app-name>
+  ./upgrade.sh <web-app-name> <api-app-name> <pcf-url>
   ```
 
 

--- a/deployment/deploy-cf.sh
+++ b/deployment/deploy-cf.sh
@@ -4,8 +4,7 @@ set -e
 
 WEB_HOST=$1
 API_HOST=$2
-API_ENDPOINT=${3:-https://api.run.pivotal.io}
-APP_DOMAIN=${4:-cfapps.io}
+APP_DOMAIN=${3:-cfapps.io}
 SESSION_TIME=${SESSION_TIME:-'""'}
 
 # The directory in which this script is located
@@ -13,7 +12,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ASSETS_DIR="$SCRIPT_DIR"/assets
 CONFIG_DIR="$SCRIPT_DIR"/config
 
-cf login -a "${API_ENDPOINT}"
+cf target \
+  || (echo 'You need to have the CF CLI installed and be logged in' \
+    && exit 1)
 
 cf push -f "$CONFIG_DIR"/manifest-api.yml -p "$ASSETS_DIR"/api --var api-app-name=$API_HOST --var web-app-name=$WEB_HOST --var pcf-url=${APP_DOMAIN} --var session-time=$SESSION_TIME
 cf run-task $API_HOST 'ADMIN_EMAIL=email@example.com ADMIN_PASSWORD=password rake admin:create_user'

--- a/deployment/upgrade-cf.sh
+++ b/deployment/upgrade-cf.sh
@@ -4,8 +4,7 @@ set -e
 
 WEB_HOST=$1
 API_HOST=$2
-API_ENDPOINT=${3:-https://api.run.pivotal.io}
-APP_DOMAIN=${4:-cfapps.io}
+APP_DOMAIN=${3:-cfapps.io}
 SESSION_TIME=${SESSION_TIME:-'""'}
 
 # The directory in which this script is located
@@ -13,9 +12,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ASSETS_DIR="$SCRIPT_DIR"/assets
 CONFIG_DIR="$SCRIPT_DIR"/config
 
-cf login -a $API_ENDPOINT
+cf target \
+  || (echo 'You need to have the CF CLI installed and be logged in' \
+    && exit 1)
 
-cf push -f "$CONFIG_DIR"/manifest-api.yml -p "$ASSETS_DIR"/api --var api-app-name=$API_HOST --var web-app-name=$WEB_HOST --var pcf-url=$CF_URL --var session-time=$SESSION_TIME
+cf push -f "$CONFIG_DIR"/manifest-api.yml -p "$ASSETS_DIR"/api --var api-app-name=$API_HOST --var web-app-name=$WEB_HOST --var pcf-url=${APP_DOMAIN} --var session-time=$SESSION_TIME
 
 sed \
   -e "s/{{api-app-name}}/${API_HOST}/" \

--- a/humans.txt
+++ b/humans.txt
@@ -49,3 +49,6 @@ Contact: callum@seadowg.com
 
 Engineer: Mike Kenyon
 Contact: mike.kenyon@gmail.com
+
+Engineer: Max Brauer
+Contact: github.com/mamachanko

--- a/package.sh
+++ b/package.sh
@@ -54,7 +54,7 @@ cp -r web/build package/heroku/assets/web/public_html
 
 # Docs
 
-cp deployment/INSTRUCTIONS.md package
+cp deployment/README.md package
 
 # Zip
 


### PR DESCRIPTION
* A short explanation of the proposed change:

     * Fix reference to CF URL in CF upgrade script
     * Remove the login from the CF upgrade/deploy scripts

* An explanation of the use cases your change solves

     * Avoids following issue during upgrade:

           Incorrect Usage: invalid argument for flag `--var' (expected []template.VarKV): Expected var 'pcf-url=' to specify non-empty value

     * Removing the login makes it easier to use e.g. SSO-only foundations.

* Links to any other associated PRs

    Some changes previously suggested in #128 

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to) - added @mamachanko 
