### PR TITLE
ensure meh tab colour is same as column

### DIFF
--- a/web/src/stylesheets/_palette.scss
+++ b/web/src/stylesheets/_palette.scss
@@ -40,7 +40,7 @@ $notification: #a0e4db;
 $action: $light-brown-background;
 
 $tab-happy: #51c0b1;
-$tab-meh: #feaf22;
+$tab-meh: #fec722;
 $tab-sad: $primary-red;
 $tab-action: #dbd7cb;
 


### PR DESCRIPTION
Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This PR fixes the colour of the meh tab when in mobile mode

* An explanation of the use cases your change solves
It is more pleasing to the eye

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [ ] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
