### PR TITLE
Add script to send installation analytics via MixPanel

### DIFF
--- a/deployment/deploy-cf.sh
+++ b/deployment/deploy-cf.sh
@@ -2,13 +2,15 @@
 
 set -e
 
+# The directory in which this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/mixpanel.sh" "$(basename "${BASH_SOURCE[0]}")" "$@"
+
 WEB_HOST=$1
 API_HOST=$2
 APP_DOMAIN=${3:-cfapps.io}
 SESSION_TIME=${SESSION_TIME:-'""'}
 
-# The directory in which this script is located
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ASSETS_DIR="$SCRIPT_DIR"/assets
 CONFIG_DIR="$SCRIPT_DIR"/config
 

--- a/deployment/deploy-cf.sh
+++ b/deployment/deploy-cf.sh
@@ -4,7 +4,7 @@ set -e
 
 # The directory in which this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-"$SCRIPT_DIR/mixpanel.sh" "$(basename "${BASH_SOURCE[0]}")" "$@"
+"$SCRIPT_DIR/mixpanel.sh" "CF $(basename "${BASH_SOURCE[0]}")" "$@"
 
 WEB_HOST=$1
 API_HOST=$2

--- a/deployment/deploy-heroku.sh
+++ b/deployment/deploy-heroku.sh
@@ -38,12 +38,14 @@ if [ $# -ne 2 ]; then
   exit 1
 fi
 
+# The directory in which this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/mixpanel.sh" "$(basename "${BASH_SOURCE[0]}")" "$@"
+
 WEB_HOST=$1
 API_HOST=$2
 SESSION_TIME=${SESSION_TIME:-'""'}
 
-# The directory in which this script is located
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ASSETS_DIR="$SCRIPT_DIR"/assets
 CONFIG_DIR="$SCRIPT_DIR"/config
 

--- a/deployment/deploy-heroku.sh
+++ b/deployment/deploy-heroku.sh
@@ -40,7 +40,7 @@ fi
 
 # The directory in which this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-"$SCRIPT_DIR/mixpanel.sh" "$(basename "${BASH_SOURCE[0]}")" "$@"
+"$SCRIPT_DIR/mixpanel.sh" "Heroku $(basename "${BASH_SOURCE[0]}")" "$@"
 
 WEB_HOST=$1
 API_HOST=$2

--- a/deployment/mixpanel.sh
+++ b/deployment/mixpanel.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo 'usage: ./mixpanel.sh <script-name> ...'
+  echo 'This will report the script execution to MixPanel.'
+  echo 'Use ANALYTICS=0 (skip) or ANALYTICS=1 (send) to avoid the manual check.'
+  exit 1
+fi
+
+ANALYTICS=${ANALYTICS:-2}
+MIXPANEL_TOKEN='d4de349453cc697734eced9ebedcdb22'
+PAYLOAD="{\"event\": \"Ran $1\", \"properties\": {\"token\": \"$MIXPANEL_TOKEN\", \"time\": $(date +%s)}}"
+URL="https:/api.mixpanel.com/track/?data=$(echo -n "$PAYLOAD" | base64)"
+
+case $ANALYTICS in
+  0)
+    exit 0;
+  ;;
+  1)
+    echo "MixPanel response (1 means success): $(curl "$URL")";
+    exit 0;
+  ;;
+  2)
+    echo 'As the maintainers of Postfacto, we are interested in gaining more information'
+    echo 'about installs so that we can make Postfacto better for you and other users.'
+    echo ''
+    echo "To let us know you've installed Postfacto, we would like to send the following "
+    echo 'information via MixPanel:'
+    echo ''
+    echo "$PAYLOAD"
+    echo ''
+    echo -n 'Do you want to send this anonymous installation notification? [yN] '
+    read -r ACCEPT
+    if [[ $ACCEPT =~ 'y' ]]; then
+      echo ''
+      echo 'Thanks for supporting Postfacto!'
+      echo ''
+      echo 'You can use ANALYTICS=1 to avoid this check in the future.'
+      echo ''
+      echo "MixPanel response (1 means success): $(curl "$URL")"
+    else
+      echo 'Skipping analytics. Use ANALYTICS=0 to avoid this check in the future.'
+    fi
+  ;;
+esac

--- a/deployment/mixpanel.sh
+++ b/deployment/mixpanel.sh
@@ -34,24 +34,24 @@ set -euo pipefail
 if [ $# -lt 1 ]; then
   echo 'usage: ./mixpanel.sh <script-name> ...'
   echo 'This will report the script execution to MixPanel.'
-  echo 'Use ANALYTICS=0 (skip) or ANALYTICS=1 (send) to avoid the manual check.'
+  echo 'Use ENABLE_ANALYTICS=false (skip) or ENABLE_ANALYTICS=true (send) to avoid the manual check.'
   exit 1
 fi
 
-ANALYTICS=${ANALYTICS:-2}
+ENABLE_ANALYTICS=${ENABLE_ANALYTICS:-unknown}
 MIXPANEL_TOKEN='d4de349453cc697734eced9ebedcdb22'
 PAYLOAD="{\"event\": \"Ran $1\", \"properties\": {\"token\": \"$MIXPANEL_TOKEN\", \"time\": $(date +%s)}}"
 URL="https:/api.mixpanel.com/track/?data=$(echo -n "$PAYLOAD" | base64)"
 
-case $ANALYTICS in
-  0)
+case $ENABLE_ANALYTICS in
+  'false')
     exit 0;
   ;;
-  1)
+  'true')
     echo "MixPanel response (1 means success): $(curl "$URL")";
     exit 0;
   ;;
-  2)
+  *)
     echo 'As the maintainers of Postfacto, we are interested in gaining more information'
     echo 'about installs so that we can make Postfacto better for you and other users.'
     echo ''
@@ -66,11 +66,11 @@ case $ANALYTICS in
       echo ''
       echo 'Thanks for supporting Postfacto!'
       echo ''
-      echo 'You can use ANALYTICS=1 to avoid this check in the future.'
+      echo 'You can use ENABLE_ANALYTICS=true to avoid this check in the future.'
       echo ''
       echo "MixPanel response (1 means success): $(curl "$URL")"
     else
-      echo 'Skipping analytics. Use ANALYTICS=0 to avoid this check in the future.'
+      echo 'Skipping analytics. Use ENABLE_ANALYTICS=false to avoid this check in the future.'
     fi
   ;;
 esac

--- a/deployment/mixpanel.sh
+++ b/deployment/mixpanel.sh
@@ -62,7 +62,7 @@ case $ANALYTICS in
     echo ''
     echo -n 'Do you want to send this anonymous installation notification? [yN] '
     read -r ACCEPT
-    if [[ $ACCEPT =~ 'y' ]]; then
+    if [[ $ACCEPT == y ]]; then
       echo ''
       echo 'Thanks for supporting Postfacto!'
       echo ''

--- a/deployment/upgrade-cf.sh
+++ b/deployment/upgrade-cf.sh
@@ -2,13 +2,15 @@
 
 set -e
 
+# The directory in which this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/mixpanel.sh" "$(basename "${BASH_SOURCE[0]}")" "$@"
+
 WEB_HOST=$1
 API_HOST=$2
 APP_DOMAIN=${3:-cfapps.io}
 SESSION_TIME=${SESSION_TIME:-'""'}
 
-# The directory in which this script is located
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ASSETS_DIR="$SCRIPT_DIR"/assets
 CONFIG_DIR="$SCRIPT_DIR"/config
 

--- a/deployment/upgrade-cf.sh
+++ b/deployment/upgrade-cf.sh
@@ -4,7 +4,7 @@ set -e
 
 # The directory in which this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-"$SCRIPT_DIR/mixpanel.sh" "$(basename "${BASH_SOURCE[0]}")" "$@"
+"$SCRIPT_DIR/mixpanel.sh" "CF $(basename "${BASH_SOURCE[0]}")" "$@"
 
 WEB_HOST=$1
 API_HOST=$2

--- a/deployment/upgrade-heroku.sh
+++ b/deployment/upgrade-heroku.sh
@@ -38,11 +38,13 @@ if [ $# -ne 2 ]; then
   exit 1
 fi
 
+# The directory in which this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/mixpanel.sh" "$(basename "${BASH_SOURCE[0]}")" "$@"
+
 WEB_HOST=$1
 API_HOST=$2
 
-# The directory in which this script is located
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ASSETS_DIR="$SCRIPT_DIR"/assets
 CONFIG_DIR="$SCRIPT_DIR"/config
 

--- a/deployment/upgrade-heroku.sh
+++ b/deployment/upgrade-heroku.sh
@@ -40,7 +40,7 @@ fi
 
 # The directory in which this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-"$SCRIPT_DIR/mixpanel.sh" "$(basename "${BASH_SOURCE[0]}")" "$@"
+"$SCRIPT_DIR/mixpanel.sh" "Heroku $(basename "${BASH_SOURCE[0]}")" "$@"
 
 WEB_HOST=$1
 API_HOST=$2

--- a/package.sh
+++ b/package.sh
@@ -20,6 +20,7 @@ popd
 cp -r deployment/pws package
 cp -r deployment/deploy-cf.sh package/pws/deploy.sh
 cp -r deployment/upgrade-cf.sh package/pws/upgrade.sh
+cp -r deployment/mixpanel.sh package/pws/mixpanel.sh
 chmod u+x package/pws/*.sh
 
 mkdir package/pws/assets
@@ -33,6 +34,7 @@ cp -r web/build package/pws/assets/web
 cp -r deployment/pcf package
 cp -r deployment/deploy-cf.sh package/pcf/deploy.sh
 cp -r deployment/upgrade-cf.sh package/pcf/upgrade.sh
+cp -r deployment/mixpanel.sh package/pcf/mixpanel.sh
 chmod u+x package/pcf/*.sh
 
 mkdir package/pcf/assets
@@ -46,6 +48,7 @@ cp -r web/build package/pcf/assets/web
 cp -r deployment/heroku package
 cp -r deployment/deploy-heroku.sh package/heroku/deploy.sh
 cp -r deployment/upgrade-heroku.sh package/heroku/upgrade.sh
+cp -r deployment/mixpanel.sh package/heroku/mixpanel.sh
 chmod u+x package/heroku/*.sh
 
 rm -rf api/tmp/*

--- a/test-package.sh
+++ b/test-package.sh
@@ -91,15 +91,15 @@ then
 
   pushd "$SCRIPT_DIR/last-release/package/pcf"
     echo 'Deploying old version to Cloud Foundry'
-    ANALYTICS=0 ./deploy.sh $OLD_WEB $OLD_API 'apps.pcfone.io'
+    ENABLE_ANALYTICS=false ./deploy.sh $OLD_WEB $OLD_API 'apps.pcfone.io'
   popd
 
   pushd "$SCRIPT_DIR/package/pcf"
     echo 'Upgrading old version on Cloud Foundry'
-    ANALYTICS=0 ./upgrade.sh $OLD_WEB $OLD_API 'apps.pcfone.io'
+    ENABLE_ANALYTICS=false ./upgrade.sh $OLD_WEB $OLD_API 'apps.pcfone.io'
 
     echo 'Deploying new version to Cloud Foundry'
-    ANALYTICS=0 ./deploy.sh $NEW_WEB $NEW_API 'apps.pcfone.io'
+    ENABLE_ANALYTICS=false ./deploy.sh $NEW_WEB $NEW_API 'apps.pcfone.io'
   popd
 
   echo 'Cleaning up Cloud Foundry'
@@ -128,15 +128,15 @@ then
 
   pushd "$SCRIPT_DIR/last-release/package/heroku"
     echo 'Deploying old version to Heroku'
-    ANALYTICS=0 ./deploy.sh $OLD_WEB $OLD_API
+    ENABLE_ANALYTICS=false ./deploy.sh $OLD_WEB $OLD_API
   popd
 
   pushd "$SCRIPT_DIR/package/heroku"
     echo 'Upgrading old version on Heroku'
-    ANALYTICS=0 ./upgrade.sh $OLD_WEB $OLD_API
+    ENABLE_ANALYTICS=false ./upgrade.sh $OLD_WEB $OLD_API
 
     echo 'Deploying new version to Heroku'
-    ANALYTICS=0 ./deploy.sh $NEW_WEB $NEW_API
+    ENABLE_ANALYTICS=false ./deploy.sh $NEW_WEB $NEW_API
   popd
 
   echo 'Cleaning up Heroku'

--- a/test-package.sh
+++ b/test-package.sh
@@ -91,15 +91,15 @@ then
 
   pushd "$SCRIPT_DIR/last-release/package/pcf"
     echo 'Deploying old version to Cloud Foundry'
-    ./deploy.sh $OLD_WEB $OLD_API 'apps.pcfone.io'
+    ANALYTICS=0 ./deploy.sh $OLD_WEB $OLD_API 'apps.pcfone.io'
   popd
 
   pushd "$SCRIPT_DIR/package/pcf"
     echo 'Upgrading old version on Cloud Foundry'
-    ./upgrade.sh $OLD_WEB $OLD_API 'apps.pcfone.io'
+    ANALYTICS=0 ./upgrade.sh $OLD_WEB $OLD_API 'apps.pcfone.io'
 
     echo 'Deploying new version to Cloud Foundry'
-    ./deploy.sh $NEW_WEB $NEW_API 'apps.pcfone.io'
+    ANALYTICS=0 ./deploy.sh $NEW_WEB $NEW_API 'apps.pcfone.io'
   popd
 
   echo 'Cleaning up Cloud Foundry'
@@ -128,15 +128,15 @@ then
 
   pushd "$SCRIPT_DIR/last-release/package/heroku"
     echo 'Deploying old version to Heroku'
-    ./deploy.sh $OLD_WEB $OLD_API
+    ANALYTICS=0 ./deploy.sh $OLD_WEB $OLD_API
   popd
 
   pushd "$SCRIPT_DIR/package/heroku"
     echo 'Upgrading old version on Heroku'
-    ./upgrade.sh $OLD_WEB $OLD_API
+    ANALYTICS=0 ./upgrade.sh $OLD_WEB $OLD_API
 
     echo 'Deploying new version to Heroku'
-    ./deploy.sh $NEW_WEB $NEW_API
+    ANALYTICS=0 ./deploy.sh $NEW_WEB $NEW_API
   popd
 
   echo 'Cleaning up Heroku'


### PR DESCRIPTION
Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

    Introduces a new script, `mixpanel.sh`, that is used during deployment/upgrade to anonymously inform the maintainers that someone's using Postfacto.

* An explanation of the use cases your change solves

    Currently we don't know how many people are installing/upgrading Postfacto instances using these scripts, so it's hard to make sensible product decisions.

* Links to any other associated PRs

    Split out of #174 

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
