### PR TITLE
Remove unwanted files from the package zip

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -53,6 +53,7 @@ fi
 mkdir tmp
 cp -r api/. tmp
 rm -rf .gitignore
+rm -rf .bundle
 rm -rf tmp/client/*
 rm -rf tmp/db/*.sqlite3
 rm -rf tmp/log/*.log

--- a/package.sh
+++ b/package.sh
@@ -52,6 +52,7 @@ fi
 
 mkdir tmp
 cp -r api/. tmp
+rm -rf .gitignore
 rm -rf tmp/client/*
 rm -rf tmp/db/*.sqlite3
 rm -rf tmp/log/*.log


### PR DESCRIPTION
Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

    Exclude the `api/.gitignore` file and `api/.bundle` directory from the `package.zip` that forms part of the release.

* An explanation of the use cases your change solves

    Fixes #193. This was causing issues with the Heroku deploy, which is based on making then pushing a commit and was therefore excluding the built client assets. Removing the `.gitignore` file alone meant that the `.bundle/config` file was included, which interfered with dependency installation, so I've removed that from the package too.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
