### PR TITLE
Switch image base to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /web
 RUN npm ci
 RUN npm run build
 
-FROM ruby:2.6.3
+FROM ruby:2.6.3-alpine
 RUN gem install bundler:2.0.1
 
 COPY ./api /postfacto
@@ -46,9 +46,22 @@ COPY --from=front-end /web/build /postfacto/client/
 
 WORKDIR /postfacto
 
+# Nokogiri dependencies
+RUN apk add --update \
+  build-base \
+  libxml2-dev \
+  libxslt-dev
+
+RUN apk add --update \
+  mariadb-dev \
+  postgresql-dev \
+  sqlite-dev
+
+RUN apk add --update nodejs
+
+RUN bundle config build.nokogiri --use-system-libraries
 RUN bundle install --without test
-RUN apt-get update -qq
-RUN apt-get install -y nodejs
+
 RUN bundle exec rake assets:precompile
 
 ENV RAILS_ENV production
@@ -59,9 +72,4 @@ ENV ENABLE_ANALYTICS false
 EXPOSE 3000
 
 ENTRYPOINT "/entrypoint"
-
-
-
-
-
 

--- a/deployment/helm/Chart.yaml
+++ b/deployment/helm/Chart.yaml
@@ -44,7 +44,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0-beta
+version: 0.2.0-beta
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.


### PR DESCRIPTION
Using alpine rather than the default ubuntu massively reduces the number
of CVEs in the final container and reduces the image size

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [ ] I have run all the tests using `./test.sh`.

* [ ] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [ ] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
