### PR TITLE
Fix references to files to delete in package script (fixes #207)

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -52,8 +52,8 @@ fi
 
 mkdir tmp
 cp -r api/. tmp
-rm -rf .gitignore
-rm -rf .bundle
+rm -rf tmp/.gitignore
+rm -rf tmp/.bundle
 rm -rf tmp/client/*
 rm -rf tmp/db/*.sqlite3
 rm -rf tmp/log/*.log


### PR DESCRIPTION
Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

    Actually removes the `.bundle` directory and `.gitignore` file from the packaged assets.

* An explanation of the use cases your change solves

    Heroku deployment uses git to push the assets, so the ignore file was causing the built client assets not to be included. This meant that, although the admin panel worked and no data was impacted, you couldn't actually use the app.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the tests using `./test.sh`.

* [ ] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [ ] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
