### PR TITLE
Add HEROKU_REGION to configure app region

### DIFF
--- a/deployment/deploy-heroku.sh
+++ b/deployment/deploy-heroku.sh
@@ -43,6 +43,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 APP_HOST=$1
 SESSION_TIME=${SESSION_TIME:-'""'}
+HEROKU_REGION=${HEROKU_REGION:-'us'}
 
 ASSETS_DIR="$SCRIPT_DIR/../assets"
 CONFIG_DIR="$SCRIPT_DIR/config"
@@ -56,7 +57,7 @@ cp "$CONFIG_DIR/Procfile" "$ASSETS_DIR"
 ###################
 
 pushd "$ASSETS_DIR"
-  heroku create ${APP_HOST} --buildpack https://github.com/heroku/heroku-buildpack-ruby.git#v200
+  heroku create ${APP_HOST} --buildpack https://github.com/heroku/heroku-buildpack-ruby.git#v200 --region ${HEROKU_REGION}
   heroku addons:create heroku-postgresql:hobby-dev -a ${APP_HOST}
   heroku addons:create heroku-redis:hobby-dev -a ${APP_HOST}
   heroku config:set WEBSOCKET_PORT=4443 SESSION_TIME=${SESSION_TIME} -a ${APP_HOST}


### PR DESCRIPTION
Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

  This change enables you to deploy Postfacto to a Heroku region of your choice.
  Run `heroku regions` to list available regions.

  ```gherkin
  Given I have set $HEROKU_REGION
  When I run the Heroku deployment script
  Then the app will be deployed into the configured region
  ```

  Example:
  ```bash
  HEROKU_REGION='eu' ./deploy.sh <app-name>
  ```

  When `HEROKU_REGION` is not set the app will deploy to the default `us` region.

* An explanation of the use cases your change solves

  Allows deployment to the Heroku region nearest to your Postfacto users to reduce latency.

* Links to any other associated PRs

  None.

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [ ] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
