### PR TITLE
Flaky Felicity E2E test click workaround (fixes #162)

### DIFF
--- a/e2e/spec/spec_helper.rb
+++ b/e2e/spec/spec_helper.rb
@@ -181,10 +181,17 @@ module SpecHelpers
   def mark_all_retro_items_as_done
     sleep(0.3)
     find_all('div.retro-item').each do |retro_item|
-      retro_item.click
+      item_id = retro_item[:id]
+      non_flaky_click("##{item_id}")
       sleep(0.3)
-      retro_item.find('.item-done').click
+      non_flaky_click("##{item_id} .item-done")
     end
+  end
+
+  # This is a workaround for Capybara/Selenium click inconsistencies
+  # https://medium.com/@yuliaoletskaya/capybara-inconsistent-click-behavior-and-flickering-tests-f50b5fae8ab2
+  def non_flaky_click(selector)
+    page.execute_script("document.querySelector('#{selector}').click()")
   end
 
   def in_browser(name, &block)


### PR DESCRIPTION
Signed-off-by: Marco Garofalo <mgarofalo@pivotal.io>

Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Invoke Javascript click for marking retro items as 'done' instead of relying on Capybara/Selenium click which seems to be inconsistent. (https://medium.com/@yuliaoletskaya/capybara-inconsistent-click-behavior-and-flickering-tests-f50b5fae8ab2)

* An explanation of the use cases your change solves
Flaky Felicity Journey E2E test. (#162)

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [ ] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
