### PR TITLE
Fix proptype warnings in test by supplying goofs for missing callbacks

### DIFF
--- a/web/src/Application.test.jsx
+++ b/web/src/Application.test.jsx
@@ -30,7 +30,7 @@ describe('Application', () => {
   });
 
   it('passes the URL to the websocket', () => {
-    const config = {websocket_url, websocket_port: 1111};
+    const config = {websocket_url, websocket_port: 1111, contact: '', terms: '', privacy: ''};
 
     const app = mount(<EnhancedApplication config={config}/>);
 

--- a/web/src/components/retro-show/retro_actions_column.test.jsx
+++ b/web/src/components/retro-show/retro_actions_column.test.jsx
@@ -32,6 +32,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
 import '../../spec_helper';
+import goof from '../../test_support/test_doubles/goof';
 
 import RetroActionsColumn from './retro_actions_column';
 
@@ -99,12 +100,18 @@ function mockDate(date) {
   global.Date.now = () => date.getTime();
 }
 
+const goofs = {
+  deleteRetroActionItem: goof,
+  doneRetroActionItem: goof,
+  editRetroActionItem: goof,
+};
+
 describe('RetroActionsColumn Current', () => {
   let dom;
 
   beforeEach(() => {
     mockDate(new Date(2016, 7, 18));
-    dom = mount(<RetroActionsColumn retroId={retroId} retro={retro} category="current"/>);
+    dom = mount(<RetroActionsColumn retroId={retroId} retro={retro} category="current" {...goofs}/>);
   });
 
   it('displays the current date in column header', () => {
@@ -128,7 +135,7 @@ describe('RetroActionsColumn last-week', () => {
 
   describe('multiple action items from different dates', () => {
     beforeEach(() => {
-      dom = mount(<RetroActionsColumn retroId={retroId} retro={retro} category="last-week"/>);
+      dom = mount(<RetroActionsColumn retroId={retroId} retro={retro} category="last-week" {...goofs}/>);
     });
 
     it('displays the last week date in column header', () => {
@@ -172,7 +179,7 @@ describe('RetroActionsColumn last-week', () => {
 
     it('renders no items', () => {
       mockDate(new Date(2016, 7, 18));
-      dom = mount(<RetroActionsColumn retroId={retroId} retro={retro_without_older} category="last-week"/>);
+      dom = mount(<RetroActionsColumn retroId={retroId} retro={retro_without_older} category="last-week" {...goofs}/>);
       expect(dom.find('.retro-action').length).toEqual(0);
     });
   });
@@ -183,7 +190,7 @@ describe('RetroActionsColumn older', () => {
 
   beforeEach(() => {
     mockDate(new Date(2016, 7, 18));
-    dom = mount(<RetroActionsColumn retroId={retroId} retro={retro} category="older"/>);
+    dom = mount(<RetroActionsColumn retroId={retroId} retro={retro} category="older" {...goofs}/>);
   });
 
   it('displays a column header', () => {
@@ -200,7 +207,7 @@ describe('RetroActionsColumn Current Archive', () => {
 
   beforeEach(() => {
     mockDate(new Date(2016, 7, 18));
-    dom = mount(<RetroActionsColumn retroId={retroId} retro={retro} category="current" archives/>);
+    dom = mount(<RetroActionsColumn retroId={retroId} retro={retro} category="current" archives {...goofs}/>);
   });
 
   describe('column header', () => {
@@ -219,7 +226,7 @@ describe('RetroActionsColumn last-week Archive', () => {
 
   beforeEach(() => {
     mockDate(new Date(2016, 7, 18));
-    dom = mount(<RetroActionsColumn retroId={retroId} retro={retro} category="last-week" archives/>);
+    dom = mount(<RetroActionsColumn retroId={retroId} retro={retro} category="last-week" archives {...goofs}/>);
   });
 
   it('is empty', () => {

--- a/web/src/components/retro-show/retro_column.test.jsx
+++ b/web/src/components/retro-show/retro_column.test.jsx
@@ -32,6 +32,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
 import '../../spec_helper';
+import goof from '../../test_support/test_doubles/goof';
 
 import RetroColumn from './retro_column';
 
@@ -70,7 +71,7 @@ describe('RetroColumn', () => {
   let dom;
 
   beforeEach(() => {
-    dom = mount(<RetroColumn retro={retro} retroId="retro-slug-123" category="happy" isMobile={false}/>);
+    dom = mount(<RetroColumn retro={retro} retroId="retro-slug-123" category="happy" isMobile={false} createRetroActionItem={goof} createRetroItem={goof} deleteRetroItem={goof} doneRetroItem={goof} extendTimer={goof} highlightRetroItem={goof} undoneRetroItem={goof} unhighlightRetroItem={goof} updateRetroItem={goof} voteRetroItem={goof}/>);
   });
 
   it('assigns a class name based on category', () => {

--- a/web/src/components/retro-show/retro_column_item.test.jsx
+++ b/web/src/components/retro-show/retro_column_item.test.jsx
@@ -33,6 +33,7 @@ import React from 'react';
 import {mount} from 'enzyme';
 import Scroll from 'react-scroll';
 import '../../spec_helper';
+import goof from '../../test_support/test_doubles/goof';
 
 import RetroColumnItem from './retro_column_item';
 
@@ -65,6 +66,7 @@ describe('RetroColumnItem', () => {
         updateRetroItem={updateRetroItem}
         deleteRetroItem={deleteRetroItem}
         scrollTo={scrollTo}
+        extendTimer={goof}
         {...props}
       />
     );
@@ -270,7 +272,7 @@ describe('RetroColumnItem', () => {
     let dom;
 
     beforeEach(() => {
-      dom = mount(<RetroColumnItem
+      dom = mount(<WiredRetroColumnItem
         retroId={retroId}
         item={item}
         highlighted_item_id={null}

--- a/web/src/components/retro-show/show_retro_page.test.jsx
+++ b/web/src/components/retro-show/show_retro_page.test.jsx
@@ -34,6 +34,7 @@ import {mount} from 'enzyme';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import Dialog from 'material-ui/Dialog';
 import '../../spec_helper';
+import goof from '../../test_support/test_doubles/goof';
 
 import {ShowRetroPage} from './show_retro_page';
 import RetroWebsocket from './retro_websocket';
@@ -90,6 +91,20 @@ function UnconnectedShowRetroPage(props) {
       requireRetroLogin={jest.fn()}
       showDialog={jest.fn()}
       signOut={jest.fn()}
+      voteRetroItem={goof}
+      doneRetroItem={goof}
+      undoneRetroItem={goof}
+      highlightRetroItem={goof}
+      unhighlightRetroItem={goof}
+      updateRetroItem={goof}
+      deleteRetroItem={goof}
+      deleteRetroActionItem={goof}
+      createRetroItem={goof}
+      createRetroActionItem={goof}
+      doneRetroActionItem={goof}
+      editRetroActionItem={goof}
+      extendTimer={goof}
+      websocketRetroDataReceived={goof}
       {...props}
     />
   );

--- a/web/src/components/retro-show/show_retro_page_archives.test.jsx
+++ b/web/src/components/retro-show/show_retro_page_archives.test.jsx
@@ -34,6 +34,7 @@ import {mount} from 'enzyme';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import {getMenuLabels} from '../../test_support/retro_menu_getters';
 import '../../spec_helper';
+import goof from '../../test_support/test_doubles/goof';
 
 import {ShowRetroPage} from './show_retro_page';
 
@@ -104,16 +105,30 @@ describe('Show retro page archives', () => {
             featureFlags={{archiveEmails: true}}
             environment={{isMobile640: false}}
             getRetroArchive={jest.fn()}
-            getRetro={jest.fn()}
-            nextRetroItem={jest.fn()}
-            archiveRetro={jest.fn()}
-            hideDialog={jest.fn()}
-            toggleSendArchiveEmail={jest.fn()}
+            getRetro={goof}
+            nextRetroItem={goof}
+            archiveRetro={goof}
+            hideDialog={goof}
+            toggleSendArchiveEmail={goof}
             routeToRetroArchives={routeToRetroArchives}
-            routeToRetroSettings={jest.fn()}
-            requireRetroLogin={jest.fn()}
-            showDialog={jest.fn()}
-            signOut={jest.fn()}
+            routeToRetroSettings={goof}
+            requireRetroLogin={goof}
+            showDialog={goof}
+            signOut={goof}
+            voteRetroItem={goof}
+            doneRetroItem={goof}
+            undoneRetroItem={goof}
+            highlightRetroItem={goof}
+            unhighlightRetroItem={goof}
+            updateRetroItem={goof}
+            deleteRetroItem={goof}
+            createRetroActionItem={goof}
+            createRetroItem={goof}
+            doneRetroActionItem={goof}
+            deleteRetroActionItem={goof}
+            editRetroActionItem={goof}
+            extendTimer={goof}
+            websocketRetroDataReceived={goof}
           />
         </MuiThemeProvider>
       ));
@@ -162,17 +177,31 @@ describe('Show retro page archives', () => {
             config={config}
             featureFlags={{archiveEmails: true}}
             environment={{isMobile640: true}}
-            getRetroArchive={jest.fn()}
-            getRetro={jest.fn()}
-            nextRetroItem={jest.fn()}
-            archiveRetro={jest.fn()}
-            hideDialog={jest.fn()}
-            toggleSendArchiveEmail={jest.fn()}
+            getRetroArchive={jest.fn()} // should we test that this is called?
+            getRetro={goof}
+            nextRetroItem={goof}
+            archiveRetro={goof}
+            hideDialog={goof}
+            toggleSendArchiveEmail={goof}
             routeToRetroArchives={routeToRetroArchives}
-            routeToRetroSettings={jest.fn()}
-            requireRetroLogin={jest.fn()}
-            showDialog={jest.fn()}
-            signOut={jest.fn()}
+            routeToRetroSettings={goof}
+            requireRetroLogin={goof}
+            showDialog={goof}
+            signOut={goof}
+            voteRetroItem={goof}
+            doneRetroItem={goof}
+            undoneRetroItem={goof}
+            highlightRetroItem={goof}
+            unhighlightRetroItem={goof}
+            updateRetroItem={goof}
+            deleteRetroItem={goof}
+            createRetroActionItem={goof}
+            createRetroItem={goof}
+            doneRetroActionItem={goof}
+            deleteRetroActionItem={goof}
+            editRetroActionItem={goof}
+            extendTimer={goof}
+            websocketRetroDataReceived={goof}
           />
         </MuiThemeProvider>
       ));

--- a/web/src/components/retro-show/show_retro_page_settings.test.jsx
+++ b/web/src/components/retro-show/show_retro_page_settings.test.jsx
@@ -34,6 +34,7 @@ import {mount} from 'enzyme';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import {invokeMenuOption} from '../../test_support/retro_menu_getters';
 import '../../spec_helper';
+import goof from '../../test_support/test_doubles/goof';
 
 import {ShowRetroPage} from './show_retro_page';
 
@@ -85,6 +86,20 @@ describe('Retro settings', () => {
           routeToRetroArchives={jest.fn()}
           showDialog={jest.fn()}
           signOut={jest.fn()}
+          voteRetroItem={goof}
+          doneRetroActionItem={goof}
+          undoneRetroItem={goof}
+          highlightRetroItem={goof}
+          unhighlightRetroItem={goof}
+          updateRetroItem={goof}
+          deleteRetroItem={goof}
+          createRetroActionItem={goof}
+          createRetroItem={goof}
+          doneRetroItem={goof}
+          deleteRetroActionItem={goof}
+          editRetroActionItem={goof}
+          extendTimer={goof}
+          websocketRetroDataReceived={goof}
         />
       </MuiThemeProvider>
     ));

--- a/web/src/test_support/test_doubles/goof.js
+++ b/web/src/test_support/test_doubles/goof.js
@@ -29,17 +29,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-import {shallow} from 'enzyme';
-import '../../spec_helper';
-import goof from '../../test_support/test_doubles/goof';
-
-import RetroWebsocket from './retro_websocket';
-
-describe('RetroWebsocket', () => {
-  it('creates a setup cable', () => {
-    const webSocketDOM = shallow(<RetroWebsocket url="wss://websocket/url" retro_id="retro-slug-123" websocketRetroDataReceived={goof}/>);
-    const {cable} = webSocketDOM.state();
-    expect(cable.url).toEqual('wss://websocket/url');
-  });
-});
+export default function goof() {
+  throw new Error("Ya goofed! This isn't implemented and wasn't expected to be called.");
+}


### PR DESCRIPTION
* A short explanation of the proposed change:

Running `./test.sh` was outputting about 500 extra lines of warnings when running the `web` tests due to PropTypes on components set to required but not being satisfied.  These tests are updated to provide goof implementations to satisfy the PropType requirement and throw an error if any of the parameters are unintentionally called during the test.

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
