### PR TITLE
Cache Travis CI dependencies between test builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
         - $TRAVIS_BUILD_DIR/deployment/helm/postfacto-*.tgz
   - name: "Build & Test Package"
     script:
-    - docker run -v "$TRAVIS_BUILD_DIR":/postfacto postfacto/dev:2.6.3-12.6.0 /bin/bash -c "cd /postfacto && npm config set user 0 && npm config set unsafe-perm true && ./deps.sh && ./package.sh"
+    - docker run -v $TRAVIS_BUILD_DIR/.npm_cache:/npm_cache -v $TRAVIS_BUILD_DIR/.bundler_cache:/bundler_cache -v "$TRAVIS_BUILD_DIR":/postfacto -e npm_config_cache=/npm_cache -e BUNDLE_PATH=/bundler_cache postfacto/dev:2.6.3-12.6.0 /bin/bash -c "cd /postfacto && npm config set user 0 && npm config set unsafe-perm true && ./deps.sh && ./package.sh"
     before_deploy:
       - openssl aes-256-cbc -K $encrypted_5e88d222d606_key -iv $encrypted_5e88d222d606_iv -in .heroku-netrc.enc -out .heroku-netrc -d
       - cat .heroku-netrc >> $HOME/.netrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: bionic
 cache:
   directories:
     - .bundler_cache
+    - .npm_cache
 
 addons:
   apt:
@@ -21,7 +22,7 @@ jobs:
   - stage: "Test"
     name: "All Tests"
     script:
-      - docker run -v $TRAVIS_BUILD_DIR/.bundler_cache:/bundler_cache -v "$TRAVIS_BUILD_DIR":/postfacto -e BUNDLE_PATH=/bundler_cache postfacto/dev:2.6.3-12.6.0 /bin/bash -c "cd /postfacto && npm config set user 0 && npm config set unsafe-perm true && ./deps.sh && EPHEMERAL_CONTAINER=true ./test.sh"
+      - docker run -v $TRAVIS_BUILD_DIR/.npm_cache:/npm_cache -v $TRAVIS_BUILD_DIR/.bundler_cache:/bundler_cache -v "$TRAVIS_BUILD_DIR":/postfacto -e npm_config_cache=/npm_cache -e BUNDLE_PATH=/bundler_cache postfacto/dev:2.6.3-12.6.0 /bin/bash -c "cd /postfacto && npm config set user 0 && npm config set unsafe-perm true && ./deps.sh && EPHEMERAL_CONTAINER=true ./test.sh"
   - stage: "Package"
   - name: "Build & Deploy Docker"
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: minimal
 
 dist: bionic
 
+cache:
+  directories:
+    - .bundler_cache
+
 addons:
   apt:
     sources:
@@ -17,7 +21,7 @@ jobs:
   - stage: "Test"
     name: "All Tests"
     script:
-      - docker run -v "$TRAVIS_BUILD_DIR":/postfacto postfacto/dev:2.6.3-12.6.0 /bin/bash -c "cd /postfacto && npm config set user 0 && npm config set unsafe-perm true && ./deps.sh && EPHEMERAL_CONTAINER=true ./test.sh"
+      - docker run -v $TRAVIS_BUILD_DIR/.bundler_cache:/bundler_cache -v "$TRAVIS_BUILD_DIR":/postfacto -e BUNDLE_PATH=/bundler_cache postfacto/dev:2.6.3-12.6.0 /bin/bash -c "cd /postfacto && npm config set user 0 && npm config set unsafe-perm true && ./deps.sh && EPHEMERAL_CONTAINER=true ./test.sh"
   - stage: "Package"
   - name: "Build & Deploy Docker"
     script:


### PR DESCRIPTION
* A short explanation of the proposed change:

Currently the gems and node modules are being downloaded fresh every time the build runs.  By caching these dependencies, Travis should not have to download each time, and therefore it should be much faster.

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
