### PR TITLE
Upgrade foundation-sites to 6.6.3

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9953,9 +9953,9 @@
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "foundation-sites": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.5.3.tgz",
-      "integrity": "sha512-ZwI0idjHHjezh6jRjpPxkczvmtUuJ1uGatZHpyloX0MvsFHfM0BFoxrqdXryXugGPdmb+yJi3JYMnz6+5t3K1A=="
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-6.6.3.tgz",
+      "integrity": "sha512-8X93wUAmUg1HhVv8uWMWnwoBLSQWSmFImJencneIZDctswn724Bq/MV1cbPZN/GFWGOB/9ngoQHztfzd4+ovCg=="
     },
     "fragment-cache": {
       "version": "0.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "actioncable": "^5.2.4",
-    "foundation-sites": "6.5.3",
+    "foundation-sites": "6.6.3",
     "grapnel": "^0.7.2",
     "http-proxy-middleware": "^0.21.0",
     "material-ui": "^0.20.2",

--- a/web/src/stylesheets/_settings.scss
+++ b/web/src/stylesheets/_settings.scss
@@ -312,7 +312,7 @@ $callout-link-tint: 30%;
 $closebutton-position: right top;
 $closebutton-offset-horizontal: 1rem;
 $closebutton-offset-vertical: 0.5rem;
-$closebutton-size: 2em;
+$closebutton-default-size: medium;
 $closebutton-lineheight: 1;
 $closebutton-color: $dark-gray;
 $closebutton-color-hover: $black;


### PR DESCRIPTION
* A short explanation of the proposed change:

Upgrading foundation-sites based on snyk trying and failing to do so.  It looks like there's some ancient configuration in _settings.scss that conflicted with some changes in foundation, so we've updated the setting to reflect that change.  It actually seems like the component that the broken setting was for isn't even being used, so potentially worth looking at taking out unused @includes at some point.

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
