### PR TITLE
Upgrade heroku buildpack from v200 to v215

### DIFF
--- a/deployment/deploy-heroku.sh
+++ b/deployment/deploy-heroku.sh
@@ -57,7 +57,7 @@ cp "$CONFIG_DIR/Procfile" "$ASSETS_DIR"
 ###################
 
 pushd "$ASSETS_DIR"
-  heroku create ${APP_HOST} --buildpack https://github.com/heroku/heroku-buildpack-ruby.git#v200 --region ${HEROKU_REGION}
+  heroku create ${APP_HOST} --buildpack https://github.com/heroku/heroku-buildpack-ruby.git#v215 --region ${HEROKU_REGION}
   heroku addons:create heroku-postgresql:hobby-dev -a ${APP_HOST}
   heroku addons:create heroku-redis:hobby-dev -a ${APP_HOST}
   heroku config:set WEBSOCKET_PORT=4443 SESSION_TIME=${SESSION_TIME} -a ${APP_HOST}

--- a/deployment/upgrade-heroku.sh
+++ b/deployment/upgrade-heroku.sh
@@ -59,7 +59,7 @@ cp "$CONFIG_DIR/config.js" "$ASSETS_DIR/client"
 cp "$CONFIG_DIR/Procfile" "$ASSETS_DIR"
 
 pushd "$ASSETS_DIR"
-  BUILDPACK='https://github.com/heroku/heroku-buildpack-ruby.git#v200'
+  BUILDPACK='https://github.com/heroku/heroku-buildpack-ruby.git#v215'
   if [[ ! $(heroku buildpacks -a ${APP_HOST}) =~ ${BUILDPACK} ]]; then
     heroku buildpacks:set -a ${APP_HOST} ${BUILDPACK}
   fi


### PR DESCRIPTION
* A short explanation of the proposed change:

v200 of the heroku buildpack does not detect Rails 6 in the Gemfile properly.  Upgrading to the latest released stable version of the buildpack.

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)

Signed-off-by: Jenny Lea <jlea@pivotal.io>