### PR TITLE
Increase the click target size of the retro item vote heart

### DIFF
--- a/web/src/stylesheets/_app.scss
+++ b/web/src/stylesheets/_app.scss
@@ -793,15 +793,15 @@ button:focus {
     .item-vote-submit {
       display: inline-block;
       text-align: center;
-      background-color: $white;
+      background-color: transparent;
       color: $light-black;
       font-size: 16px;
       border-radius: 1rem;
-      margin: 0;
-      padding: 0;
+      margin: -1.25em;
+      padding: 1.25em;
 
       &:hover {
-        background-color: $white;
+        background-color: transparent;
       }
 
       .vote-count {

--- a/web/src/stylesheets/_app.scss
+++ b/web/src/stylesheets/_app.scss
@@ -790,6 +790,9 @@ button:focus {
       cursor: pointer;
     }
 
+    $item-vote-vertical-extension: 0.9em;
+    $item-vote-horizontal-extension: 1.25em;
+
     .item-vote-submit {
       display: inline-block;
       text-align: center;
@@ -797,8 +800,8 @@ button:focus {
       color: $light-black;
       font-size: 16px;
       border-radius: 1rem;
-      margin: -1.25em;
-      padding: 1.25em;
+      margin: (-$item-vote-vertical-extension) (-$item-vote-horizontal-extension);
+      padding: $item-vote-vertical-extension $item-vote-horizontal-extension;
 
       &:hover {
         background-color: transparent;


### PR DESCRIPTION
* A short explanation of the proposed change:

Make the click area for the upvote heart bigger so that people trying to vote don't accidentally start presenting a retro board item.

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)

Signed-off-by: Jenny Lea <jlea@pivotal.io>