### PR TITLE
Update helm chart to use bitnami for postgres and redis, as stable is…

### DIFF
--- a/deployment/helm/Chart.lock
+++ b/deployment/helm/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.bitnami.com/bitnami
   version: 6.5.0
 - name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com
+  repository: https://charts.bitnami.com/bitnami
   version: 9.4.3
-digest: sha256:18dea218d4c6460be6a3b7b203d6668650e1a9dfe42a4859ccdd7f5ebc6b9038
-generated: "2020-05-12T14:21:00.129069+01:00"
+digest: sha256:370a0cefafd00e023a76d01a3a785252db4cd17fbf19f5ee4a3adcc282092d3a
+generated: "2020-05-29T12:28:49.817707+01:00"

--- a/deployment/helm/Chart.yaml
+++ b/deployment/helm/Chart.yaml
@@ -44,7 +44,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.0-beta
+version: 0.5.0-beta
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -53,7 +53,7 @@ appVersion: latest
 dependencies:
   - name: postgresql
     version: 6.5.0
-    repository: "@stable"
+    repository: "@bitnami"
   - name: redis
     version: 9.4.3
-    repository: "@stable"
+    repository: "@bitnami"

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -92,9 +92,9 @@ option for postgres you would add the following to the install/upgrade command
 To build the chart locally, follow the following steps
 
 1. Install Helm CLI (version 3+)
-1. Add stable chart repository to helm
+1. Add Bitnami chart repository to helm
     ```shell script
-    helm repo add stable https://kubernetes-charts.storage.googleapis.com
+    helm repo add bitnami https://charts.bitnami.com/bitnami
     ```
 1. Download subcharts:
     ```shell script

--- a/deployment/helm/build.sh
+++ b/deployment/helm/build.sh
@@ -39,7 +39,7 @@ fi
 
 sed -i.bak s/appVersion:.*/appVersion:\ $APP_VERSION/  Chart.yaml
 
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
+helm repo add bitnami https://charts.bitnami.com/bitnami
 
 helm dependency build
 


### PR DESCRIPTION
* A short explanation of the proposed change:
As mentioned in #248, Helm stable repository is getting deprecated in favour of a distributed model. Postfacto and Redis are both maintained by Bitnami, so this change updates the helm chart to use the Bitnami repository instead. 

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
