### PR TITLE
Allow items to be voted on even when another item is being presented

### DIFF
--- a/web/src/components/retro-show/retro_column_item.jsx
+++ b/web/src/components/retro-show/retro_column_item.jsx
@@ -123,7 +123,7 @@ export default class RetroColumnItem extends React.Component {
   onItemVoteClicked(event) {
     event.stopPropagation();
     const {item, retroId, archives} = this.props;
-    if (this.isEnabled() && !this.isDone() && !archives) {
+    if (!this.isDone() && !archives) {
       this.props.voteRetroItem(retroId, item);
     }
   }

--- a/web/src/components/retro-show/retro_column_item.test.jsx
+++ b/web/src/components/retro-show/retro_column_item.test.jsx
@@ -188,6 +188,11 @@ describe('RetroColumnItem', () => {
       it('hides edit button', () => {
         expect(dom.find('.item-edit i')).not.toExist();
       });
+
+      it('does record votes', () => {
+        dom.find('.item-vote-submit').simulate('click');
+        expect(voteRetroItem).toHaveBeenCalled();
+      });
     });
 
     it('scrolls to the centre of the screen when highlighted', () => {


### PR DESCRIPTION
* A short explanation of the proposed change:

Allow retro items to be voted on even when an item is being presented as requested in #141 

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
