### PR TITLE
Fix CF directory referenced in the test package script

### DIFF
--- a/test-package.sh
+++ b/test-package.sh
@@ -87,7 +87,7 @@ then
     sleep 5
   done
 
-  pushd "$SCRIPT_DIR/last-release/package/pcf"
+  pushd "$SCRIPT_DIR/last-release/package/cf"
     echo 'Deploying old version to Cloud Foundry'
     ENABLE_ANALYTICS=false ./deploy.sh $OLD_APP
   popd


### PR DESCRIPTION
* A short explanation of the proposed change:
When testing the package, we deploy the last released version and then confirm we can upgrade.  As `pcf` is now called `cf`, the directory that the package script deploys the previous release from needs to change as well.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
