### PR TITLE
Split up packaging and testing deployment in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,10 @@ jobs:
         skip_cleanup: true
         on:
           tags: true
-  - name: "Build & Test Package"
+  - name: "Build & Upload Package"
     script:
       - docker run -v $TRAVIS_BUILD_DIR/deployment/helm/:/helm  -w /helm --entrypoint /helm/build.sh alpine/helm:3.2.1 $TRAVIS_TAG
-      - docker run -v $TRAVIS_BUILD_DIR/.npm_cache:/npm_cache -v $TRAVIS_BUILD_DIR/.bundler_cache:/bundler_cache -v "$TRAVIS_BUILD_DIR":/postfacto -e npm_config_cache=/npm_cache -e BUNDLE_PATH=/bundler_cache postfacto/dev:2.6.3-12.6.0 /bin/bash -c "cd /postfacto && npm config set user 0 && npm config set unsafe-perm true && ./deps.sh && ./package.sh"
-    before_deploy:
-      - openssl aes-256-cbc -K $encrypted_5e88d222d606_key -iv $encrypted_5e88d222d606_iv -in .heroku-netrc.enc -out .heroku-netrc -d
-      - cat .heroku-netrc >> $HOME/.netrc
-      - cf login -a $CF_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD
-      - ./test-package.sh --skip-package
+      - docker run -v $TRAVIS_BUILD_DIR/.npm_cache:/npm_cache -v $TRAVIS_BUILD_DIR/.bundler_cache:/bundler_cache -v "$TRAVIS_BUILD_DIR":/postfacto -e npm_config_cache=/npm_cache -e BUNDLE_PATH=/bundler_cache postfacto/dev:2.6.3-12.6.0 /bin/bash -c "cd /postfacto && npm config set user 0 && npm config set unsafe-perm true && ./deps.sh && ./package.sh $TRAVIS_TAG"
     deploy:
       - provider: releases
         draft: true
@@ -53,6 +48,23 @@ jobs:
         api_key:
           secure: dPDprfJo3c5iCk5fcPR7tgRMz5OcCF6IAPRx1/WMAq1FJjgdkD6iu628/AAgezN/rlTDiqZpfx3nj3UhTSUOeBZgEaRbpvpIc3bLc2RABqqxQNuL2g+DNt3L7XYcq8PLHQBVIHmRKp8DK1XJCaG3LUEuYZD9gKaiftMwbvgsgfVOFasslyypgDTi/NdPm1tNsDdKvYVe9dkZpDpHClJsoIQLl/gtNvrJREFTF2w0T8oSdccsoQekAAC4kXWiL5lgXIKHDpQTo1K8oXrl/hUxuw0e1fGKA6R0kNZliA6cQYG3OOb0a9JhplzO3jGWvlZdmJluWgy0yUn+jRZZOXiQVJOZCd2Lht3JN8p6x9D91S43forMV7ZmrW3XPuEocGIwVdY7yVKEsHAiAK3Ih3VbMuUn1ITvKB8F4idyurWEL9cQwsszX9pFSOriAH5mhIQs7vwp6uvFJIoADGiS//wEqcAwzsFWHCDLBPYRTk9Zp17MSgUj8+PDBo29pbbWtx6+14w82LVQQdnyoReDiZR5G1ItxSx6xjWIeGlyo8yu4xmNq9nufPoj6ZkGDbAJtH2YeaGIEcltjXzIalmBdmoVp+6SKyr8EFnolgWd+ns8KkCvLqxp3fwuz4OD+B619Au1/8WUrHRdetChlvxzEHVx3wnwWnw0zbCBh/cq0mWUdzs=
         file:
-        - package.zip
-        - $TRAVIS_BUILD_DIR/deployment/helm/postfacto-*.tgz
-
+          - package.zip
+          - $TRAVIS_BUILD_DIR/deployment/helm/postfacto-*.tgz
+  - stage: "Test Deployment"
+  - name: "Deploy on Cloud Foundry"
+    deploy:
+      on:
+        tags: true
+      script:
+        - ./download-draft-package.sh
+        - cf login -a $CF_ENDPOINT -u $CF_USERNAME -p $CF_PASSWORD
+        - ./test-package.sh --skip-package --skip-heroku
+  - name: "Deploy on Heroku"
+    deploy:
+      on:
+        tags: true
+      script:
+        - ./download-draft-package.sh
+        - openssl aes-256-cbc -K $encrypted_5e88d222d606_key -iv $encrypted_5e88d222d606_iv -in .heroku-netrc.enc -out .heroku-netrc -d
+        - cat .heroku-netrc >> $HOME/.netrc
+        - ./test-package.sh --skip-package --skip-cf

--- a/download-draft-package.sh
+++ b/download-draft-package.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Get the asset url of the latest draft
+asset_url=$(curl -u $GITHUB_USERNAME:$ACCESS_TOKEN \
+          --header "Accept: application/json" \
+          https://api.github.com/repos/pivotal/postfacto/releases \
+          | jq --raw-output '[.[] | select(.draft==true)][0].assets[0].url')
+
+# Download asset
+curl --location --silent --show-error \
+          -u $GITHUB_USERNAME:$ACCESS_TOKEN \
+          --header "Accept: application/octet-stream" \
+          --output $SCRIPT_DIR/package.zip \
+          $asset_url

--- a/download-draft-package.sh
+++ b/download-draft-package.sh
@@ -1,4 +1,33 @@
 #!/bin/sh
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 


### PR DESCRIPTION
* A short explanation of the proposed change:

This change splits the deployment tests for Cloud Foundry and Heroku into separate jobs. To do this we have moved the creation of package.zip into an earlier stage, where it is uploaded to Github as a draft and then downloaded by the deployment tests.

* An explanation of the use cases your change solves

Currently the deployment testing for Cloud Foundry and Heroku are part of the same Travis job, this means that they some times hit the Travis time limit of 50 minutes and time out. This change runs them in parallel, which should also reduce the overall build time.

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
