### PR TITLE
Add header to scripts that were missing it

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -1,5 +1,33 @@
 #!/bin/bash
-
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 set -e
 
 BASE_DIR="$(dirname "$0")"

--- a/docker.sh
+++ b/docker.sh
@@ -1,5 +1,33 @@
 #!/bin/bash
-
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 mkdir -p "$(pwd)/docker_node_modules"
 
 docker run -it \

--- a/docker/ci-push
+++ b/docker/ci-push
@@ -1,4 +1,33 @@
 #!/bin/bash
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 set -e
 
 TAG=$1

--- a/e2e.sh
+++ b/e2e.sh
@@ -1,5 +1,33 @@
 #!/bin/bash
-
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 set -e
 
 BASE_DIR="$(dirname "$0")"

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,33 @@
 #!/bin/bash
-
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 set -e
 
 BASE_DIR="$(dirname "$0")"

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,33 @@
 #!/bin/bash
-
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 set -e
 
 BASE_DIR="$(dirname "$0")"


### PR DESCRIPTION
Signed-off-by: Marco Garofalo <mgarofalo@pivotal.io>

* A short explanation of the proposed change:

Add licensing header to all of the scripts for consistency.

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
