### PR TITLE
Delete all associated items and action items when deleting a retro

### DIFF
--- a/api/app/models/archive.rb
+++ b/api/app/models/archive.rb
@@ -30,6 +30,6 @@
 #
 class Archive < ApplicationRecord
   belongs_to :retro, optional: true
-  has_many :items
-  has_many :action_items
+  has_many :items, dependent: :destroy
+  has_many :action_items, dependent: :destroy
 end

--- a/api/app/models/retro.rb
+++ b/api/app/models/retro.rb
@@ -33,7 +33,7 @@ class Retro < ActiveRecord::Base
 
   has_many :items, -> { order(:created_at).where(archived: false) }, dependent: :destroy
   has_many :action_items, -> { order(:created_at).where(archived: false) }, dependent: :destroy
-  has_many :archives
+  has_many :archives, dependent: :destroy
 
   belongs_to :user, optional: true
   enum item_order: { time: 'time', votes: 'votes' }

--- a/api/spec/model/retro_spec.rb
+++ b/api/spec/model/retro_spec.rb
@@ -114,6 +114,33 @@ describe Retro do
     end
   end
 
+  context 'deleting a retro' do
+    let(:retro) { Retro.create(name: 'My Retro') }
+    let(:done_item) { Item.new(description: 'item1', category: :happy, done: true) }
+    let(:done_action) { ActionItem.new(description: 'action1', done: true) }
+    let(:current_item) { Item.new(description: 'item2', category: :happy, done: false) }
+    let(:current_action) { ActionItem.new(description: 'action2', done: false) }
+
+    it 'should delete all items and action items associated with the retro' do
+      retro.items << done_item
+      retro.action_items << done_action
+
+      RetroArchiveService.archive(retro, Time.now, false)
+
+      retro.reload
+
+      retro.items << current_item
+      retro.action_items << current_action
+
+      retro.destroy!
+
+      expect(Item.where(id: current_item.id)).not_to exist
+      expect(Item.where(id: done_item.id)).not_to exist
+      expect(ActionItem.where(id: current_action.id)).not_to exist
+      expect(ActionItem.where(id: done_action.id)).not_to exist
+    end
+  end
+
   context 'retro has an invalid slug' do
     let(:retro) { Retro.new(name: 'My Retro') }
 


### PR DESCRIPTION
* A short explanation of the proposed change:

Currently only non-archived items and action items are deleted along with the retro.  This deletes all the records associated with the retro when the retro is deleted including: archives, items, and action items.

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
