### PR TITLE
Formatting issue with multi line items

### DIFF
--- a/web/src/components/retro-show/retro_column_input.jsx
+++ b/web/src/components/retro-show/retro_column_input.jsx
@@ -214,8 +214,10 @@ export default class RetroColumnInput extends React.Component {
               autoComplete="off"
               innerRef={(ref) => { this.textarea = ref; }}
             />
-            {this.renderEmojiButton()}
-            {this.renderDoneButton()}
+            <div className="input-buttons">
+              {this.renderEmojiButton()}
+              {this.renderDoneButton()}
+            </div>
           </div>
           {this.renderEmojiSelector()}
         </div>

--- a/web/src/stylesheets/_app.scss
+++ b/web/src/stylesheets/_app.scss
@@ -1006,6 +1006,11 @@ button:focus {
     }
   }
 
+  .input-buttons {
+    display: flex;
+    justify-content: flex-end;
+  }
+
   &.multiline {
     flex-direction: column;
   }


### PR DESCRIPTION
* A short explanation of the proposed change:
Fix formatting issue with multiline retro items

* An explanation of the use cases your change solves
Buttons' positions in a multiline retro item are stacked instead of being next to each other as mentioned in issue #199  

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
