### PR TITLE
Add TOC link to TKG section [skip ci]

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -3,6 +3,7 @@
 ## Contents
   * [Prerequisites](#prerequisites)
   * [Tanzu Application Service](#tanzu-application-service)
+  * [Tanzu Kubernetes Grid (vSphere)](#tanzu-kubernetes-grid-vsphere)
   * [Pivotal Web Services](#pivotal-web-services)
   * [Cloud Foundry](#cloud-foundry)
   * [Heroku](#heroku)


### PR DESCRIPTION
Thanks for contributing to Postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Adds a link to the TKG section of the deployment docs into the TOC in the README (see preview at https://github.com/textbook/postfacto/tree/docs-fix-tkg-toc/deployment#contents)

* An explanation of the use cases your change solves

So anyone looking to run Postfacto on TKG can easily find the right instructions, or anyone looking to run Postfacto generally can see that TKG is one of the options.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the tests using `./test.sh`.

* [ ] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [ ] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
