### PR TITLE
Fix a bug where Alex only ever sees retros marked as private

### DIFF
--- a/api/app/admin/retros.rb
+++ b/api/app/admin/retros.rb
@@ -132,7 +132,7 @@ ActiveAdmin.register Retro do
       f.input :slug
       f.input :video_link
       f.input :owner_email, label: 'Owner Email'
-      f.input :is_private, label: 'Private?', input_html: { checked: f.object.is_private || true }
+      f.input :is_private, label: 'Private?'
     end
 
     f.inputs do
@@ -154,6 +154,12 @@ ActiveAdmin.register Retro do
 
     def find_user_by_email(owner_email)
       User.find_by_email(owner_email)
+    end
+
+    def new
+      super do
+        @retro.is_private = true
+      end
     end
 
     def update

--- a/api/spec/admin/admin_retros_request_spec.rb
+++ b/api/spec/admin/admin_retros_request_spec.rb
@@ -168,6 +168,30 @@ describe '/admin/retros', type: :request do
     end
   end
 
+  describe 'new' do
+    it 'has Private? checked by default' do
+      get new_admin_retro_path
+
+      doc = Nokogiri::HTML(response.body)
+      is_checked = doc.xpath('//input[@id="retro_is_private"]')[0]['checked']
+
+      expect(is_checked).to eq('checked')
+    end
+  end
+
+  describe 'edit' do
+    it 'should reflect the value of Private?' do
+      retro.update!(is_private: false)
+
+      get edit_admin_retro_path(retro.id)
+
+      doc = Nokogiri::HTML(response.body)
+      is_checked = doc.xpath('//input[@id="retro_is_private"]')[0]['checked']
+
+      expect(is_checked).not_to eq('checked')
+    end
+  end
+
   describe 'index CSV export' do
     it 'includes the desired columns' do
       get admin_retros_path + '.csv'


### PR DESCRIPTION
* A short explanation of the proposed change:

Updated Admin page to properly show whether a retro is private or not.  

Closes #284.

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
