### PR TITLE
Add share retro functionality via magic link

### DIFF
--- a/api/app/admin/retros.rb
+++ b/api/app/admin/retros.rb
@@ -33,7 +33,7 @@ require 'queries/safe_order_by'
 ActiveAdmin.register Retro do
   menu priority: 1
   actions :all
-  permit_params :name, :slug, :video_link, :password, :encrypted_password, :is_private
+  permit_params :name, :slug, :video_link, :password, :encrypted_password, :is_private, :is_magic_link_enabled
 
   filter :name
   filter :slug
@@ -127,12 +127,19 @@ ActiveAdmin.register Retro do
   form do |f|
     f.semantic_errors
 
+    private_label =  '<strong> Make this retro private? </strong> ' +
+      '<p class="checkbox-description">A private retro requires a password to access. A public retro can be accessed by anyone.</p> '
+
+    magic_link_label = '<strong> Share this retro using a magic link? </strong>' +
+      '<p class="checkbox-description"> This will provide a magic link that allows users to access' +
+      ' this retro without being prompted for a password. This is not the same as making a retro public.</p>'
     f.inputs 'Details' do
       f.input :name
       f.input :slug
       f.input :video_link
       f.input :owner_email, label: 'Owner Email'
-      f.input :is_private, label: 'Private?', input_html: { checked: f.object.is_private || true }
+      f.input :is_private, label: simple_format(private_label, { class: 'checkbox-label'} ), input_html: { checked: f.object.is_private || true }
+      f.input :magic_link_enabled?, label: simple_format(magic_link_label, { class: 'checkbox-label'} ) , as: :boolean, input_html: { checked: f.object.magic_link_enabled? }
     end
 
     f.inputs do
@@ -171,6 +178,9 @@ ActiveAdmin.register Retro do
       if params['retro']['remove_password'] && params['retro']['remove_password'][1] == 'Remove'
         params[:retro][:encrypted_password] = nil
       end
+
+      params[:retro][:is_magic_link_enabled] = params['retro']['magic_link_enabled?'] == "1"
+      params[:retro].delete('magic_link_enabled?')
 
       params[:retro].delete('remove_password')
       update!

--- a/api/app/controllers/retros_controller.rb
+++ b/api/app/controllers/retros_controller.rb
@@ -59,7 +59,9 @@ class RetrosController < ApplicationController
     if @retro.save # TODO: no error handling
       broadcast_force_relogin if force_relogin_required?
       broadcast
-      render json: { retro: @retro.as_json(only: [:id, :name, :slug, :is_private, :video_link]) }, status: :ok
+      render json: {
+        retro: @retro.as_json(only: [:id, :name, :slug, :is_private, :video_link, :join_token])
+      }, status: :ok
     else
       render json: { errors: retro_errors_hash }, status: :unprocessable_entity
     end
@@ -113,7 +115,7 @@ class RetrosController < ApplicationController
   end
 
   def retro_params
-    params.require(:retro).permit(:name, :slug, :password, :item_order, :is_private)
+    params.require(:retro).permit(:name, :slug, :password, :item_order, :is_private, :is_magic_link_enabled)
   end
 
   def retro_archive_params
@@ -121,7 +123,7 @@ class RetrosController < ApplicationController
   end
 
   def retro_update_params
-    params.permit({ retro: [:name, :slug, :is_private, :video_link] }, :request_uuid)
+    params.permit({ retro: [:name, :slug, :is_private, :video_link, :is_magic_link_enabled] }, :request_uuid)
   end
 
   def retro_update_password_params

--- a/api/app/controllers/settings_controller.rb
+++ b/api/app/controllers/settings_controller.rb
@@ -34,7 +34,7 @@ class SettingsController < ApplicationController
   before_action :load_and_authenticate_retro_admin
 
   def index
-    render json: { retro: @retro.as_json(only: [:id, :name, :slug, :is_private]) }, status: :ok
+    render json: { retro: @retro.as_json(only: [:id, :name, :slug, :is_private, :join_token]) }, status: :ok
   end
 
   private

--- a/api/app/models/retro.rb
+++ b/api/app/models/retro.rb
@@ -72,6 +72,10 @@ class Retro < ActiveRecord::Base
 
   def is_magic_link_enabled=(val)
     if ActiveModel::Type::Boolean.new.cast(val)
+      unless join_token.nil?
+        return
+      end
+
       recompute_join_token
     else
       clear_join_token

--- a/api/app/models/retro.rb
+++ b/api/app/models/retro.rb
@@ -117,7 +117,7 @@ class Retro < ActiveRecord::Base
   end
 
   def should_recompute_join_token?
-    magic_link_enabled? && :will_save_change_to_encrypted_password?
+    magic_link_enabled? && will_save_change_to_encrypted_password?
   end
 
   def recompute_join_token

--- a/api/app/views/retros/show.json.jbuilder
+++ b/api/app/views/retros/show.json.jbuilder
@@ -1,7 +1,8 @@
 json.retro do
   json.call(
     @retro, :id, :slug, :name, :is_private, :video_link,
-    :created_at, :highlighted_item_id, :retro_item_end_time, :send_archive_email
+    :created_at, :highlighted_item_id, :retro_item_end_time, :send_archive_email,
+    :join_token
   )
   json.items @retro.items, partial: 'items/item', as: :item
   json.action_items @retro.action_items, partial: 'action_items/action_item', as: :action_item

--- a/api/db/migrate/20200617144551_add_join_token_to_retros.rb
+++ b/api/db/migrate/20200617144551_add_join_token_to_retros.rb
@@ -28,33 +28,8 @@
 #
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-class RetroSerializer
-  ALLOWED_FIELDS = [
-    :created_at,
-    :highlighted_item_id,
-    :id,
-    :is_private,
-    :name,
-    :retro_item_end_time,
-    :send_archive_email,
-    :slug,
-    :updated_at,
-    :user_id,
-    :video_link,
-    :join_token
-  ].freeze
-
-  ASSOCIATIONS = {
-    action_items: {}.freeze,
-    archives: { only: :id }.freeze,
-    items: {}.freeze
-  }.freeze
-
-  def initialize(retro)
-    @retro = retro
-  end
-
-  def as_json
-    @retro.as_json(include: ASSOCIATIONS, only: ALLOWED_FIELDS)
+class AddJoinTokenToRetros < ActiveRecord::Migration[6.0]
+  def change
+    add_column :retros, :join_token, :string, :null => true
   end
 end

--- a/api/spec/model/retro_spec.rb
+++ b/api/spec/model/retro_spec.rb
@@ -100,11 +100,18 @@ describe Retro do
       expect(retro.join_token).to_not be_nil
     end
 
-    it 'does change the join token if the password is changed' do
+    it 'changes the join token if the password is changed' do
       old_join_token = retro.join_token
       retro.password = 'something-new'
       retro.save!
       expect(retro.join_token).not_to eq old_join_token
+    end
+
+    it 'does not change the join token if anything else is changed' do
+      old_join_token = retro.join_token
+      retro.name = 'My new retro name'
+      retro.save!
+      expect(retro.join_token).to eq old_join_token
     end
 
     it 'clears the join token if magic link gets disabled' do

--- a/api/spec/model/retro_spec.rb
+++ b/api/spec/model/retro_spec.rb
@@ -82,6 +82,64 @@ describe Retro do
     end
   end
 
+  context 'retro has magic link enabled' do
+    let(:retro) do
+      Retro.create!(
+        name: 'My Retro',
+        video_link: 'the-video-link',
+        password: 'some-password'
+      )
+    end
+
+    before do
+      retro.is_magic_link_enabled = true
+      retro.save!
+    end
+
+    it 'has a join token' do
+      expect(retro.join_token).to_not be_nil
+    end
+
+    it 'does change the join token if the password is changed' do
+      old_join_token = retro.join_token
+      retro.password = 'something-new'
+      retro.save!
+      expect(retro.join_token).not_to eq old_join_token
+    end
+
+    it 'clears the join token if magic link gets disabled' do
+      retro.is_magic_link_enabled = false
+      retro.save!
+      expect(retro.join_token).to be_nil
+    end
+  end
+
+  context 'retro has magic link disabled' do
+    let(:retro) do
+      Retro.create!(
+        name: 'My Retro',
+        video_link: 'the-video-link',
+        password: 'some-password'
+      )
+    end
+
+    it 'does not have a join token' do
+      expect(retro.join_token).to be_nil
+    end
+
+    it 'does populate the join token if magic link gets re-enabled' do
+      retro.is_magic_link_enabled = true
+      retro.save!
+      expect(retro.join_token).to_not be_nil
+    end
+
+    it 'does not populate the join token if the password is changed' do
+      retro.password = 'something-new'
+      retro.save!
+      expect(retro.join_token).to be_nil
+    end
+  end
+
   context 'retro has a password' do
     let(:retro) { Retro.create!(name: 'My Retro', video_link: 'the-video-link', password: 'some-password') }
 

--- a/api/spec/rails_helper.rb
+++ b/api/spec/rails_helper.rb
@@ -104,7 +104,7 @@ def token_for(item)
   case item
   when Retro
     AuthToken.generate(
-      retro.slug,
+      item.slug,
       'retros',
       CLOCK.current_time,
       nil,
@@ -113,7 +113,7 @@ def token_for(item)
 
   when User
     AuthToken.generate(
-      user.email,
+      item.email,
       'users',
       CLOCK.current_time,
       nil,

--- a/api/spec/requests/settings_request_spec.rb
+++ b/api/spec/requests/settings_request_spec.rb
@@ -48,6 +48,7 @@ describe '/retros/:id/settings' do
         expect(data['retro']['slug']).to start_with('my-retro')
         expect(data['retro']['id']).to eq(retro.id)
         expect(data['retro']['is_private']).to eq(false)
+        expect(data['retro']['join_token']).to be_nil
       end
     end
 

--- a/api/spec/serializers/retro_serializer_spec.rb
+++ b/api/spec/serializers/retro_serializer_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe RetroSerializer do
         'slug' => retro.slug,
         'updated_at' => retro.updated_at,
         'user_id' => retro.user_id,
-        'video_link' => retro.video_link
+        'video_link' => retro.video_link,
+        'join_token' => nil
       )
     end
 

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y python
 
 # Install Chrome WebDriver
 RUN apt-get update && apt-get install -y apt-transport-https ca-certificates
-RUN CHROMEDRIVER_VERSION='75.0.3770.90' && \
+RUN CHROMEDRIVER_VERSION='83.0.4103.39' && \
     mkdir -p /opt/chromedriver-$CHROMEDRIVER_VERSION && \
     curl -sS -o /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip && \
     unzip -qq /tmp/chromedriver_linux64.zip -d /opt/chromedriver-$CHROMEDRIVER_VERSION && \

--- a/e2e/Gemfile
+++ b/e2e/Gemfile
@@ -39,4 +39,5 @@ group :development, :test do
   gem 'selenium-webdriver', '>= 3.141.0'
   gem 'pry'
   gem 'pry-byebug'
+  gem 'clipboard', '~> 1.1'
 end

--- a/e2e/Gemfile.lock
+++ b/e2e/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    clipboard (1.3.4)
     coderay (1.1.2)
     diff-lcs (1.3)
     method_source (0.9.2)
@@ -58,6 +59,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara (>= 3.32.2)
+  clipboard (~> 1.1)
   pry
   pry-byebug
   rspec

--- a/e2e/spec/a_journey_of_two_participants_journey_spec.rb
+++ b/e2e/spec/a_journey_of_two_participants_journey_spec.rb
@@ -236,8 +236,7 @@ context 'A Journey Of Two Participants', type: :feature, js: true do
       visit retro_url
 
       click_button 'SHARE'
-      find('.share-retro-url-copy').click
-      Clipboard.paste.encode('UTF-8')
+      find('#share-retro-url').value
     end
 
     in_browser(:peter) do

--- a/e2e/spec/a_journey_of_two_participants_journey_spec.rb
+++ b/e2e/spec/a_journey_of_two_participants_journey_spec.rb
@@ -235,8 +235,7 @@ context 'A Journey Of Two Participants', type: :feature, js: true do
       retro_url = create_private_retro('A retro only for people with the password')
       visit retro_url
 
-      click_button 'SHARE'
-      find('#share-retro-url').value
+      get_share_url
     end
 
     in_browser(:peter) do

--- a/e2e/spec/a_journey_of_two_participants_journey_spec.rb
+++ b/e2e/spec/a_journey_of_two_participants_journey_spec.rb
@@ -229,6 +229,23 @@ context 'A Journey Of Two Participants', type: :feature, js: true do
     end
   end
 
+  specify 'sharing a retro url' do
+    retro_share_url = in_browser(:felicity) do
+      register('two-participants-sharing-felicity-user')
+      retro_url = create_private_retro('A retro only for people with the password')
+      visit retro_url
+
+      click_button 'SHARE'
+      find('.share-retro-url-copy').click
+      Clipboard.paste.encode('UTF-8')
+    end
+
+    in_browser(:peter) do
+      visit retro_share_url
+      expect(page).to have_content 'A retro only for people with the password'
+    end
+  end
+
   specify 'Public retros cannot be archived without password' do
     retro_url = ''
     view_all_archives_url = ''

--- a/e2e/spec/felicity_journey_spec.rb
+++ b/e2e/spec/felicity_journey_spec.rb
@@ -171,6 +171,43 @@ context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'tru
       end
     end
 
+    describe 'sharing a retro' do
+      share_url = ''
+
+      before do
+        retro_url = create_private_retro('Share Retro')
+        visit retro_url
+
+        share_url = get_share_url
+      end
+
+      specify 'changing the password changes the share url' do
+        click_menu_item 'Retro settings'
+        click_link 'Change password'
+
+        fill_in('current_password', with: 'password')
+        fill_in('new_password', with: 'new_password')
+        fill_in('confirm_new_password', with: 'new_password')
+
+        click_button('Save new password')
+
+        expect(page).to have_content 'Settings'
+        expect(page).to have_content 'Password changed'
+
+        click_on 'Save changes'
+
+        expect(get_share_url).not_to eq(share_url)
+      end
+
+      specify 'changing other settings does not change the share url' do
+        click_menu_item 'Retro settings'
+        fill_in 'retro_name', with: 'New Name'
+        click_on 'Save changes'
+
+        expect(get_share_url).to eq(share_url)
+      end
+    end
+
     describe 'archiving a retro' do
       describe 'summary email option' do
         xspecify 'is remembered from the last retro' do

--- a/e2e/spec/felicity_journey_spec.rb
+++ b/e2e/spec/felicity_journey_spec.rb
@@ -30,6 +30,7 @@
 #
 require 'spec_helper'
 require 'pry-byebug'
+require 'clipboard'
 
 context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'true' do
   context 'when they have not registered before' do

--- a/e2e/spec/spec_helper.rb
+++ b/e2e/spec/spec_helper.rb
@@ -87,7 +87,8 @@ module SpecHelpers
   end
 
   def create_private_retro(team_name = nil)
-    fill_in_create_retro_form
+    fill_in_create_retro_form(team_name)
+    find('#retro_is_magic_link_enabled', visible: :all).set(true)
     submit_create_retro_form(team_name)
   end
 

--- a/e2e/spec/spec_helper.rb
+++ b/e2e/spec/spec_helper.rb
@@ -190,6 +190,13 @@ module SpecHelpers
     end
   end
 
+  def get_share_url
+    click_button 'SHARE'
+    share_url = find('#share-retro-url').value
+    click_button 'Close'
+    share_url
+  end
+
   # This is a workaround for Capybara/Selenium click inconsistencies
   # https://medium.com/@yuliaoletskaya/capybara-inconsistent-click-behavior-and-flickering-tests-f50b5fae8ab2
   def non_flaky_click(selector)

--- a/web/src/api/retro_client.js
+++ b/web/src/api/retro_client.js
@@ -53,12 +53,13 @@ export default class RetroClient {
           slug: data.slug,
           password: data.password,
           is_private: data.isPrivate,
+          is_magic_link_enabled: data.isMagicLinkEnabled,
         },
       }),
     });
   }
 
-  updateRetro(id, name, slug, token, is_private, request_uuid, video_link) {
+  updateRetro(id, name, slug, token, is_private, request_uuid, video_link, is_magic_link_enabled) {
     return this.fetchJson(`${this.apiBaseUrl()}/retros/${id}`, {
       method: 'PATCH',
       accessToken: token,
@@ -68,6 +69,7 @@ export default class RetroClient {
           slug,
           is_private,
           video_link,
+          is_magic_link_enabled,
         },
         request_uuid,
       }),
@@ -99,6 +101,13 @@ export default class RetroClient {
     return this.fetchJson(`${this.apiBaseUrl()}/retros/${retro_id}/sessions`, {
       method: 'POST',
       body: JSON.stringify({retro: {password}}),
+    });
+  }
+
+  joinRetro({retro_id, join_token}) {
+    return this.fetchJson(`${this.apiBaseUrl()}/retros/${retro_id}/sessions`, {
+      method: 'POST',
+      body: JSON.stringify({retro: {join_token}}),
     });
   }
 

--- a/web/src/components/retro-create/retro_create_page.jsx
+++ b/web/src/components/retro-create/retro_create_page.jsx
@@ -61,6 +61,7 @@ class RetroCreatePage extends React.Component {
       slug: '',
       password: '',
       isPrivate: true,
+      isMagicLinkEnabled: false,
       errors: {
         name: '',
         slug: '',
@@ -111,6 +112,7 @@ class RetroCreatePage extends React.Component {
         slug: this.state.slug,
         password: this.state.password,
         isPrivate: this.state.isPrivate,
+        isMagicLinkEnabled: this.state.isMagicLinkEnabled,
       });
     }
   }
@@ -178,6 +180,12 @@ class RetroCreatePage extends React.Component {
     }));
   };
 
+  toggleMagicLinkEnabled = () => {
+    this.setState((oldState) => ({
+      isMagicLinkEnabled: !oldState.isMagicLinkEnabled,
+    }));
+  };
+
   renderAccessInstruction() {
     const accessPrivate = (
       <div>
@@ -206,7 +214,7 @@ class RetroCreatePage extends React.Component {
   }
 
   render() {
-    const {name, slug, password, isPrivate, errors} = this.state;
+    const {name, slug, password, isPrivate, isMagicLinkEnabled, errors} = this.state;
     const toggle = DEFAULT_TOGGLE_STYLE;
 
     return (
@@ -278,6 +286,31 @@ class RetroCreatePage extends React.Component {
                   iconStyle={toggle.iconStyle}
                 />
                 {this.renderAccessInstruction()}
+              </div>
+
+              <div className="row">
+                <label className="label" htmlFor="retro_is_magic_link_enabled">Can participants share this retro using a magic link?</label>
+
+                <Toggle
+                  id="retro_is_magic_link_enabled"
+                  name="isMagicLinkEnabled"
+                  label={isMagicLinkEnabled ? 'Yes' : 'No'}
+                  labelPosition="right"
+                  toggled={isMagicLinkEnabled}
+                  onToggle={this.toggleMagicLinkEnabled}
+                  trackStyle={toggle.trackStyle}
+                  trackSwitchedStyle={toggle.trackSwitchedStyle}
+                  labelStyle={toggle.labelStyle}
+                  thumbStyle={toggle.thumbStyle}
+                  thumbSwitchedStyle={toggle.thumbSwitchedStyle}
+                  iconStyle={toggle.iconStyle}
+                />
+
+                <div className="access-instruction">
+                  This will provide a magic link that allows users to access this retro
+                  without being prompted for a password. This is not the same as making a retro public.
+                </div>
+
               </div>
 
               <div className="row">

--- a/web/src/components/retro-create/retro_create_page.test.jsx
+++ b/web/src/components/retro-create/retro_create_page.test.jsx
@@ -228,9 +228,16 @@ describe('RetroCreatePage', () => {
 
   it('submits when clicking submit if all fields are valid', () => {
     dom.find('.new-retro-page input#retro_is_private').simulate('change');
+    dom.find('.new-retro-page input#retro_is_magic_link_enabled').simulate('change');
     dom.find('.retro-form-submit').simulate('click');
 
-    expect(retroCreate).toHaveBeenCalledWith({name: 'newRetro', slug: 'new-retro', password: 'retroPass', isPrivate: false});
+    expect(retroCreate).toHaveBeenCalledWith({
+      name: 'newRetro',
+      slug: 'new-retro',
+      password: 'retroPass',
+      isPrivate: false,
+      isMagicLinkEnabled: true,
+    });
   });
 
   it('redirects to home page when not logged in', () => {

--- a/web/src/components/retro-settings/show_retro_password_settings_page.jsx
+++ b/web/src/components/retro-settings/show_retro_password_settings_page.jsx
@@ -219,8 +219,8 @@ class ShowRetroPasswordSettingsPage extends React.Component {
                   <div className="error-message">{errors.confirm_new_password}</div>
                 </div>
 
-                <div className="row">
-                  <em>Remember to let your team know the new password!</em>
+                <div className="row reminder">
+                  <em>Remember to let your team know the new password{this.props.retro.join_token ? ' and magic link' : ''}!</em>
                 </div>
 
                 <div className="row actions">

--- a/web/src/components/retro-settings/show_retro_password_settings_page.test.jsx
+++ b/web/src/components/retro-settings/show_retro_password_settings_page.test.jsx
@@ -59,9 +59,9 @@ describe('ShowRetroPasswordSettingsPage', () => {
     let showRetroForId;
     let updateRetroPassword;
     let signOut;
+    const environment = {isMobile640: isMobile};
 
     beforeEach(() => {
-      const environment = {isMobile640: isMobile};
       getRetroSettings = jest.fn();
       clearErrors = jest.fn();
       showRetroForId = jest.fn();
@@ -138,6 +138,33 @@ describe('ShowRetroPasswordSettingsPage', () => {
       dom.unmount();
 
       expect(clearErrors).toHaveBeenCalled();
+    });
+
+    it('displays magic link message when a join token is present', () => {
+      dom = mount((
+        <MuiThemeProvider>
+          <ShowRetroPasswordSettingsPage
+            retroId="13"
+            retro={{
+              ...retro,
+              join_token: 'join_token',
+            }}
+            session={session}
+            environment={environment}
+            getRetroSettings={getRetroSettings}
+            clearErrors={clearErrors}
+            showRetroForId={showRetroForId}
+            updateRetroPassword={updateRetroPassword}
+            signOut={signOut}
+          />
+        </MuiThemeProvider>
+      ));
+
+      expect(dom.find('.reminder')).toIncludeText('and magic link');
+    });
+
+    it('does not display magic link message when no join token is present', () => {
+      expect(dom.find('.reminder')).not.toIncludeText('and magic link');
     });
   };
 

--- a/web/src/components/retro-settings/show_retro_settings_page.jsx
+++ b/web/src/components/retro-settings/show_retro_settings_page.jsx
@@ -51,6 +51,7 @@ function getStateUpdateFor(retro, errors) {
     stateUpdate.slug = retro.slug;
     stateUpdate.isPrivate = retro.is_private;
     stateUpdate.video_link = retro.video_link;
+    stateUpdate.isMagicLinkEnabled = retro.join_token !== null;
   }
 
   if (errors) {
@@ -100,6 +101,7 @@ class ShowRetroSettingsPage extends React.Component {
         name: '',
         slug: '',
         video_link: '',
+        isMagicLinkEnabled: false,
         errors: {},
       },
       getStateUpdateFor(retro, errors),
@@ -176,14 +178,22 @@ class ShowRetroSettingsPage extends React.Component {
 
   handleRetroSettingsSubmit() {
     const {retroId, retro, session} = this.props;
-    const {name, slug, isPrivate, video_link} = this.state;
+    const {name, slug, isPrivate, video_link, isMagicLinkEnabled} = this.state;
     const errors = {
       name: this.validateName(name),
       slug: this.validateSlug(slug),
     };
 
     if (!errors.name && !errors.slug) {
-      this.props.updateRetroSettings(retroId, name, slug, retro.slug, isPrivate, session.request_uuid, video_link);
+      this.props.updateRetroSettings(
+        retroId, name,
+        slug,
+        retro.slug,
+        isPrivate,
+        session.request_uuid,
+        video_link,
+        isMagicLinkEnabled,
+      );
     } else {
       this.setState({errors});
     }
@@ -221,6 +231,12 @@ class ShowRetroSettingsPage extends React.Component {
   togglePrivate = () => {
     this.setState((oldState) => ({
       isPrivate: !oldState.isPrivate,
+    }));
+  };
+
+  toggleMagicLinkEnabled = () => {
+    this.setState((oldState) => ({
+      isMagicLinkEnabled: !oldState.isMagicLinkEnabled,
     }));
   };
 
@@ -368,6 +384,33 @@ class ShowRetroSettingsPage extends React.Component {
                   {this.renderAccessInstruction()}
                 </div>
 
+                <div className="row">
+                  <label
+                    className="label"
+                    htmlFor="retro_is_magic_link_enabled"
+                  >Can participants share this retro using a magic link?
+                  </label>
+
+                  <Toggle
+                    id="retro_is_magic_link_enabled"
+                    name="isMagicLinkEnabled"
+                    label={this.state.isMagicLinkEnabled ? 'Yes' : 'No'}
+                    toggled={this.state.isMagicLinkEnabled}
+                    labelPosition="right"
+                    onToggle={this.toggleMagicLinkEnabled}
+                    trackStyle={toggle.trackStyle}
+                    trackSwitchedStyle={toggle.trackSwitchedStyle}
+                    labelStyle={toggle.labelStyle}
+                    thumbStyle={toggle.thumbStyle}
+                    thumbSwitchedStyle={toggle.thumbSwitchedStyle}
+                    iconStyle={toggle.iconStyle}
+                  />
+
+                  <div className="access-instruction">
+                    This will provide a magic link that allows users to access this retro without
+                    being prompted for a password. This is not the same as making a retro public.
+                  </div>
+                </div>
 
                 <div className="row">
                   <button
@@ -397,7 +440,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   clearErrors: () => dispatch(clearErrors()),
   showRetroForId: (retroId) => dispatch(showRetroForId(retroId)),
-  updateRetroSettings: (retroId, retroName, newSlug, oldSlug, isPrivate, requestUuid, videoLink) => dispatch(updateRetroSettings(retroId, retroName, newSlug, oldSlug, isPrivate, requestUuid, videoLink)),
+  updateRetroSettings: (retroId, retroName, newSlug, oldSlug, isPrivate, requestUuid, videoLink, isMagicLinkEnabled) => dispatch(updateRetroSettings(retroId, retroName, newSlug, oldSlug, isPrivate, requestUuid, videoLink, isMagicLinkEnabled)),
   routeToRetroPasswordSettings: (retroId) => dispatch(retroPasswordSettings(retroId)),
   getRetroSettings: (retroId) => dispatch(getRetroSettings(retroId)),
   signOut: () => dispatch(signOut()),

--- a/web/src/components/retro-settings/show_retro_settings_page.test.jsx
+++ b/web/src/components/retro-settings/show_retro_settings_page.test.jsx
@@ -50,6 +50,7 @@ describe('ShowRetroSettingsPage', () => {
       video_link: 'http://the/video/link',
       items: [],
       action_items: [],
+      join_token: null,
     };
 
     let dom;
@@ -245,6 +246,54 @@ describe('ShowRetroSettingsPage', () => {
       expect(dom.find('input#retro_is_private')).not.toBeChecked();
     });
 
+    describe('magic link toggle defaults to the current setting', () => {
+      it('default to true if there is a valid join token', () => {
+        const privateRetro = Object.assign({}, retro, {join_token: 'join-token'});
+        dom = mount((
+          <MuiThemeProvider>
+            <ShowRetroSettingsPage
+              retroId="13"
+              retro={privateRetro}
+              environment={environment}
+              clearErrors={clearErrors}
+              showRetroForId={showRetroForId}
+              updateRetroSettings={updateRetroSettings}
+              routeToRetroPasswordSettings={routeToRetroPasswordSettings}
+              getRetroSettings={getRetroSettings}
+              signOut={signOut}
+            />
+          </MuiThemeProvider>
+        ));
+
+        expect(dom.find('input#retro_is_magic_link_enabled')).toBeChecked();
+        dom.find('input#retro_is_magic_link_enabled').simulate('change');
+        expect(dom.find('input#retro_is_magic_link_enabled')).not.toBeChecked();
+      });
+
+      it('default to false if the join token is missing', () => {
+        const privateRetro = Object.assign({}, retro, {join_token: null});
+        dom = mount((
+          <MuiThemeProvider>
+            <ShowRetroSettingsPage
+              retroId="13"
+              retro={privateRetro}
+              environment={environment}
+              clearErrors={clearErrors}
+              showRetroForId={showRetroForId}
+              updateRetroSettings={updateRetroSettings}
+              routeToRetroPasswordSettings={routeToRetroPasswordSettings}
+              getRetroSettings={getRetroSettings}
+              signOut={signOut}
+            />
+          </MuiThemeProvider>
+        ));
+
+        expect(dom.find('input#retro_is_magic_link_enabled')).not.toBeChecked();
+        dom.find('input#retro_is_magic_link_enabled').simulate('change');
+        expect(dom.find('input#retro_is_magic_link_enabled')).toBeChecked();
+      });
+    });
+
     describe('all fields are empty', () => {
       beforeEach(() => {
         fieldRetroName.simulate('change', {target: {value: ''}});
@@ -282,9 +331,20 @@ describe('ShowRetroSettingsPage', () => {
       expect(dom.find('input#retro_is_private')).not.toBeChecked();
       dom.find('input#retro_is_private').simulate('change');
 
+      dom.find('input#retro_is_magic_link_enabled').simulate('change');
+
       dom.find('.retro-settings-form-submit').simulate('click');
 
-      expect(updateRetroSettings).toHaveBeenCalledWith('13', 'the new retro name', 'the-new-retro-slug', retro.slug, true, 'some-request-uuid', new_video_url);
+      expect(updateRetroSettings).toHaveBeenCalledWith(
+        '13',
+        'the new retro name',
+        'the-new-retro-slug',
+        retro.slug,
+        true,
+        'some-request-uuid',
+        new_video_url,
+        true,
+      );
     });
 
     it('routes to retro password settings when change password link is clicked', () => {

--- a/web/src/components/retro-show/archive_retro_dialog.jsx
+++ b/web/src/components/retro-show/archive_retro_dialog.jsx
@@ -1,0 +1,123 @@
+/*
+ * Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+ * remote teams.
+ *
+ * Copyright (C) 2016 - Present Pivotal Software, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ *
+ * it under the terms of the GNU Affero General Public License as
+ *
+ * published by the Free Software Foundation, either version 3 of the
+ *
+ * License, or (at your option) any later version.
+ *
+ *
+ *
+ * This program is distributed in the hope that it will be useful,
+ *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *
+ * GNU Affero General Public License for more details.
+ *
+ *
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import types from 'prop-types';
+import Toggle from 'material-ui/Toggle';
+import Dialog from 'material-ui/Dialog';
+import {DEFAULT_TOGGLE_STYLE} from '../shared/constants';
+
+export default class ArchiveRetroDialog extends React.Component {
+  static propTypes = {
+    title: types.string.isRequired,
+    message: types.string.isRequired,
+    retro: types.object.isRequired,
+    onClose: types.func.isRequired,
+    featureFlags: types.object.isRequired,
+    toggleSendArchiveEmail: types.func.isRequired,
+    archiveRetro: types.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.handleArchiveEmailPreferenceChange = this.handleArchiveEmailPreferenceChange.bind(this);
+    this.handleArchiveRetroConfirmation = this.handleArchiveRetroConfirmation.bind(this);
+  }
+
+  handleArchiveEmailPreferenceChange() {
+    this.props.toggleSendArchiveEmail(!this.props.retro.send_archive_email);
+  }
+
+  handleArchiveRetroConfirmation() {
+    this.props.archiveRetro(this.props.retro);
+    this.props.onClose();
+  }
+
+  render() {
+    const toggle = DEFAULT_TOGGLE_STYLE;
+
+    const archiveButton = (
+      <button
+        className="archive-dialog__actions--archive"
+        type="button"
+        onClick={this.handleArchiveRetroConfirmation}
+      >
+        {this.props.retro.send_archive_email && this.props.featureFlags.archiveEmails ? 'Archive & send email' : 'Archive'}
+      </button>
+    );
+
+    const cancelButton = (
+      <button
+        className="archive-dialog__actions--cancel"
+        type="button"
+        onClick={this.props.onClose}
+      >
+        Cancel
+      </button>
+    );
+
+    return (
+      <Dialog
+        title={this.props.title}
+        actions={[cancelButton, archiveButton]}
+        open
+        onRequestClose={this.props.onClose}
+        actionsContainerClassName="archive-dialog__actions"
+        contentClassName="archive-dialog"
+      >
+        <p>{this.props.message}</p>
+        {
+          this.props.featureFlags.archiveEmails ? (
+            <div>
+              <label className="label" htmlFor="send_archive_email">Send action items to the team via email?</label>
+
+              <Toggle
+                id="send_archive_email"
+                name="sendArchiveEmail"
+                label={this.props.retro.send_archive_email ? 'Yes' : 'No'}
+                toggled={this.props.retro.send_archive_email}
+                labelPosition="right"
+                onToggle={this.handleArchiveEmailPreferenceChange}
+                trackStyle={toggle.trackStyle}
+                trackSwitchedStyle={toggle.trackSwitchedStyle}
+                labelStyle={toggle.labelStyle}
+                thumbStyle={toggle.thumbStyle}
+                thumbSwitchedStyle={toggle.thumbSwitchedStyle}
+                iconStyle={toggle.iconStyle}
+              />
+            </div>
+          ) : null
+        }
+      </Dialog>
+    );
+  }
+}

--- a/web/src/components/retro-show/archive_retro_dialog.test.jsx
+++ b/web/src/components/retro-show/archive_retro_dialog.test.jsx
@@ -1,0 +1,165 @@
+/*
+ * Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+ * remote teams.
+ *
+ * Copyright (C) 2016 - Present Pivotal Software, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ *
+ * it under the terms of the GNU Affero General Public License as
+ *
+ * published by the Free Software Foundation, either version 3 of the
+ *
+ * License, or (at your option) any later version.
+ *
+ *
+ *
+ * This program is distributed in the hope that it will be useful,
+ *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *
+ * GNU Affero General Public License for more details.
+ *
+ *
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import '../../spec_helper';
+import {mount} from 'enzyme';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import ArchiveRetroDialog from './archive_retro_dialog';
+
+function createRetro(isPrivate = false) {
+  return {
+    id: 13,
+    name: 'the retro name',
+    is_private: isPrivate,
+    video_link: 'http://the/video/link',
+    send_archive_email: false,
+    items: [
+      {
+        id: 1,
+        description: 'the happy retro item',
+        category: 'happy',
+      },
+      {
+        id: 2,
+        description: 'the meh retro item',
+        category: 'meh',
+      },
+      {
+        id: 3,
+        description: 'the sad retro item',
+        category: 'sad',
+      },
+    ],
+    action_items: [],
+  };
+}
+
+function mountArchiveRetroDialog(props) {
+  return mount((
+    <MuiThemeProvider>
+      <ArchiveRetroDialog
+        title="foo"
+        message="Testing"
+        retro={createRetro()}
+        onClose={jest.fn()}
+        featureFlags={{archiveEmails: true}}
+        toggleSendArchiveEmail={jest.fn()}
+        archiveRetro={jest.fn()}
+        {...props}
+      />
+    </MuiThemeProvider>
+  ));
+}
+
+function getDialogElement() {
+  // Dialog renders outside usual flow, so must use hacks:
+  return document.getElementsByClassName('archive-dialog')[0];
+}
+
+describe('ArchiveRetroDialog', () => {
+  it('does not show the email toggle when the feature flag is off', () => {
+    mountArchiveRetroDialog({
+      featureFlags: {
+        archiveEmails: false,
+      },
+    });
+    const popupDialog = getDialogElement();
+    expect(popupDialog.querySelector('#send_archive_email')).toBeFalsy();
+  });
+
+  it('invokes archiveRetro and onClose when the confirmation button is clicked', () => {
+    const archiveRetro = jest.fn();
+    const onClose = jest.fn();
+    const retro = createRetro();
+    mountArchiveRetroDialog({
+      retro,
+      archiveRetro,
+      onClose,
+    });
+
+    const popupDialog = getDialogElement();
+    popupDialog.querySelector('.archive-dialog__actions--archive').click();
+
+    expect(onClose).toHaveBeenCalled();
+    expect(archiveRetro).toHaveBeenCalledWith(retro);
+  });
+
+  it('invokes onClose when the cancel button is clicked', () => {
+    const onClose = jest.fn();
+    mountArchiveRetroDialog({
+      onClose,
+    });
+
+    const popupDialog = getDialogElement();
+    popupDialog.querySelector('.archive-dialog__actions--cancel').click();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('invokes toggleSendArchiveEmail when the email preference is toggled', () => {
+    const toggleSendArchiveEmail = jest.fn();
+    const retro = createRetro();
+    retro.send_archive_email = false;
+
+    mountArchiveRetroDialog({
+      retro,
+      toggleSendArchiveEmail,
+    });
+
+    const popupDialog = getDialogElement();
+    expect(popupDialog.querySelector('.archive-dialog__actions--archive').textContent).toBe('Archive');
+    popupDialog.querySelector('#send_archive_email').click();
+    expect(toggleSendArchiveEmail).toHaveBeenCalledWith(true);
+  });
+
+  it('changes the text of the confirmation button when the email preference is toggled', () => {
+    const retro = createRetro();
+    retro.send_archive_email = true;
+
+    mountArchiveRetroDialog({
+      retro,
+    });
+
+    const popupDialog = getDialogElement();
+    expect(popupDialog.querySelector('.archive-dialog__actions--archive').textContent).toBe('Archive & send email');
+  });
+
+  it('displays title and message given in dialog', () => {
+    mountArchiveRetroDialog({
+      title: 'Some dialog title',
+      message: 'Some dialog message',
+    });
+
+    const popupDialog = getDialogElement();
+    expect(popupDialog.querySelector('h3').innerHTML).toEqual('Some dialog title');
+    expect(popupDialog.querySelector('p').innerHTML).toEqual('Some dialog message');
+  });
+});

--- a/web/src/components/retro-show/retro_heading.jsx
+++ b/web/src/components/retro-show/retro_heading.jsx
@@ -53,6 +53,7 @@ export default class RetroHeading extends React.Component {
 
     this.onArchivesButtonClicked = this.onArchivesButtonClicked.bind(this);
     this.handleArchiveRetro = this.handleArchiveRetro.bind(this);
+    this.handleShareRetro = this.handleShareRetro.bind(this);
     this.handleViewArchives = this.handleViewArchives.bind(this);
     this.handleRetroSettings = this.handleRetroSettings.bind(this);
   }
@@ -80,10 +81,33 @@ export default class RetroHeading extends React.Component {
     );
   }
 
+  renderShareButton() {
+    const {retro} = this.props;
+    if (!retro.join_token) {
+      return null;
+    }
+    return (
+      <RaisedButton
+        className="retro-heading-button share-button"
+        backgroundColor="#2574a9"
+        labelColor="#f8f8f8"
+        label="SHARE"
+        onClick={this.handleShareRetro}
+      />
+    );
+  }
+
   handleArchiveRetro() {
     this.props.showDialog({
       title: 'You\'re about to archive this retro.',
       message: 'Are you sure?',
+      type: 'ARCHIVE_RETRO',
+    });
+  }
+
+  handleShareRetro() {
+    this.props.showDialog({
+      type: 'SHARE_RETRO',
     });
   }
 
@@ -142,6 +166,7 @@ export default class RetroHeading extends React.Component {
             <h1>{retro.name}</h1>
           </div>
           <div className="retro-heading-buttons">
+            {this.renderShareButton()}
             {
               retro.video_link ? (
                 <RaisedButton

--- a/web/src/components/retro-show/retro_heading.test.jsx
+++ b/web/src/components/retro-show/retro_heading.test.jsx
@@ -43,6 +43,7 @@ const defaultRetro = {
   video_link: 'http://the/video/link',
   items: [],
   action_items: [],
+  join_token: null,
 };
 
 function createShallowRetroHeading(retroOverrides = {}, propOverrides = {}) {
@@ -103,6 +104,7 @@ describe('RetroHeading', () => {
       expect(showDialog).toHaveBeenCalledWith({
         title: 'You\'re about to archive this retro.',
         message: 'Are you sure?',
+        type: 'ARCHIVE_RETRO',
       });
     });
 
@@ -117,6 +119,36 @@ describe('RetroHeading', () => {
       it('hides the video button', () => {
         const dom = createShallowRetroHeading({video_link: null});
         expect(dom.find('.video-button')).not.toExist();
+      });
+    });
+
+    it('does not include the share button if the magic link is disabled', () => {
+      const dom = createShallowRetroHeading({
+        join_token: null,
+        items: [],
+      });
+      expect(dom.find('.share-button')).not.toExist();
+    });
+
+    it('includes the share button if the magic link is enabled', () => {
+      const dom = createShallowRetroHeading({
+        join_token: 'join-token',
+        items: [],
+      });
+      expect(dom.find('.share-button')).toExist();
+    });
+
+    it('dispatches showDialog when the share button is clicked', () => {
+      const showDialog = jest.fn();
+      const dom = createShallowRetroHeading({
+        join_token: 'join-token',
+        items: [],
+      }, {showDialog});
+
+      dom.find('.share-button').simulate('click');
+
+      expect(showDialog).toHaveBeenCalledWith({
+        type: 'SHARE_RETRO',
       });
     });
   });

--- a/web/src/components/retro-show/share_retro_dialog.jsx
+++ b/web/src/components/retro-show/share_retro_dialog.jsx
@@ -1,0 +1,90 @@
+/*
+ * Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+ * remote teams.
+ *
+ * Copyright (C) 2016 - Present Pivotal Software, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ *
+ * it under the terms of the GNU Affero General Public License as
+ *
+ * published by the Free Software Foundation, either version 3 of the
+ *
+ * License, or (at your option) any later version.
+ *
+ *
+ *
+ * This program is distributed in the hope that it will be useful,
+ *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *
+ * GNU Affero General Public License for more details.
+ *
+ *
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import types from 'prop-types';
+import Dialog from 'material-ui/Dialog';
+
+export default class ShareRetroDialog extends React.Component {
+  static propTypes = {
+    retroId: types.string.isRequired,
+    retro: types.shape({
+      join_token: types.string,
+    }).isRequired,
+    onClose: types.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.retroUrl = `${window.location.origin}/retros/${this.props.retroId}/join/${this.props.retro.join_token}`;
+    this.copyRetroUrl = this.copyRetroUrl.bind(this);
+  }
+
+  copyRetroUrl() {
+    const textToCopy = document.querySelector('#share-retro-url');
+
+    textToCopy.select();
+    textToCopy.setSelectionRange(0, 99999); /* For mobile devices */
+
+    document.execCommand('copy');
+  }
+
+  render() {
+    const closeButton = (
+      <button
+        className="share-dialog__actions--close"
+        type="button"
+        onClick={this.props.onClose}
+      >
+        Close
+      </button>
+    );
+
+    return (
+      <Dialog
+        title="Invite others to this retro"
+        actions={[closeButton]}
+        open
+        onRequestClose={this.props.onClose}
+        actionsContainerClassName="share-dialog__actions"
+        contentClassName="share-dialog"
+      >
+        Copy this link and send it to your team mates
+        <div className="share-retro-url-wrapper">
+          <input name="share-retro-url" readOnly id="share-retro-url" type="text" value={this.retroUrl}/>
+          <div className="share-retro-url-copy" onClick={this.copyRetroUrl}>
+            <i className="fa fa-copy"/>
+          </div>
+        </div>
+      </Dialog>
+    );
+  }
+}

--- a/web/src/components/retro-show/share_retro_dialog.test.jsx
+++ b/web/src/components/retro-show/share_retro_dialog.test.jsx
@@ -1,0 +1,90 @@
+/*
+ * Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+ * remote teams.
+ *
+ * Copyright (C) 2016 - Present Pivotal Software, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ *
+ * it under the terms of the GNU Affero General Public License as
+ *
+ * published by the Free Software Foundation, either version 3 of the
+ *
+ * License, or (at your option) any later version.
+ *
+ *
+ *
+ * This program is distributed in the hope that it will be useful,
+ *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *
+ * GNU Affero General Public License for more details.
+ *
+ *
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ *
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import '../../spec_helper';
+import {mount} from 'enzyme';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import ShareRetroDialog from './share_retro_dialog';
+
+
+function mountShareRetroDialog(props) {
+  return mount((
+    <MuiThemeProvider>
+      <ShareRetroDialog
+        retroId="my-retro"
+        retro={{
+          join_token: null,
+        }}
+        onClose={jest.fn()}
+        {...props}
+      />
+    </MuiThemeProvider>
+  ));
+}
+
+function getDialogElement() {
+  // Dialog renders outside usual flow, so must use hacks:
+  return document.getElementsByClassName('share-dialog')[0];
+}
+
+describe('ShareRetroDialog', () => {
+  it('copies the retro url in the clipboard when the copy button is clicked', async () => {
+    document.execCommand = jest.fn();
+    mountShareRetroDialog();
+    getDialogElement().querySelector('.share-retro-url-copy').click();
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('invokes onClose when the close button is clicked', () => {
+    const onClose = jest.fn();
+    mountShareRetroDialog({
+      onClose,
+    });
+
+    const popupDialog = getDialogElement();
+    popupDialog.querySelector('.share-dialog__actions--close').click();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('displays the current retro url', () => {
+    mountShareRetroDialog({
+      retro: {
+        join_token: 'join-token',
+      },
+    });
+
+    const retroUrl = 'http://localhost/retros/my-retro/join/join-token';
+
+    const popupDialog = getDialogElement();
+    expect(popupDialog.querySelector('input').value).toContain(retroUrl);
+  });
+});

--- a/web/src/components/retro-show/show_retro_page.jsx
+++ b/web/src/components/retro-show/show_retro_page.jsx
@@ -29,9 +29,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import Dialog from 'material-ui/Dialog';
-import Toggle from 'material-ui/Toggle';
-
 import React from 'react';
 import types from 'prop-types';
 
@@ -46,7 +43,6 @@ import RetroHeading from './retro_heading';
 
 import EmptyPage from '../shared/empty_page';
 
-import {DEFAULT_TOGGLE_STYLE} from '../shared/constants';
 import {
   archiveRetro,
   createRetroActionItem,
@@ -76,6 +72,8 @@ import {
 } from '../../redux/actions/main_actions';
 import {retroArchives, retroLogin, retroSettings} from '../../redux/actions/router_actions';
 import {websocketUrl} from '../../helpers/websockets';
+import ArchiveRetroDialog from './archive_retro_dialog';
+import ShareRetroDialog from './share_retro_dialog';
 
 function getItemArchiveTime(item) {
   if (!item.archived_at) {
@@ -96,6 +94,7 @@ class ShowRetroPage extends React.Component {
     dialog: types.shape({
       title: types.string,
       message: types.string,
+      type: types.string,
     }),
     environment: types.shape({
       isMobile640: types.bool,
@@ -265,65 +264,33 @@ class ShowRetroPage extends React.Component {
     );
   }
 
-  renderArchiveConfirmationDialog() {
-    const title = this.props.dialog ? this.props.dialog.title : '';
-    const message = this.props.dialog ? this.props.dialog.message : '';
-    const toggle = DEFAULT_TOGGLE_STYLE;
+  renderDialog() {
+    const dialogType = this.props.dialog ? this.props.dialog.type : '';
 
-    const archiveButton = (
-      <button
-        className="archive-dialog__actions--archive"
-        type="button"
-        onClick={this.handleArchiveRetroConfirmation}
-      >
-        {this.props.retro.send_archive_email && this.props.featureFlags.archiveEmails ? 'Archive & send email' : 'Archive'}
-      </button>
-    );
-
-    const cancelButton = (
-      <button
-        className="archive-dialog__actions--cancel"
-        type="button"
-        onClick={this.props.hideDialog}
-      >
-        Cancel
-      </button>
-    );
-
-    return (
-      <Dialog
-        title={title}
-        actions={[cancelButton, archiveButton]}
-        open={!!this.props.dialog}
-        onRequestClose={this.props.hideDialog}
-        actionsContainerClassName="archive-dialog__actions"
-        contentClassName="archive-dialog"
-      >
-        <p>{message}</p>
-        {
-          this.props.featureFlags.archiveEmails ? (
-            <div>
-              <label className="label" htmlFor="send_archive_email">Send action items to the team via email?</label>
-
-              <Toggle
-                id="send_archive_email"
-                name="sendArchiveEmail"
-                label={this.props.retro.send_archive_email ? 'Yes' : 'No'}
-                toggled={this.props.retro.send_archive_email}
-                labelPosition="right"
-                onToggle={this.handleArchiveEmailPreferenceChange}
-                trackStyle={toggle.trackStyle}
-                trackSwitchedStyle={toggle.trackSwitchedStyle}
-                labelStyle={toggle.labelStyle}
-                thumbStyle={toggle.thumbStyle}
-                thumbSwitchedStyle={toggle.thumbSwitchedStyle}
-                iconStyle={toggle.iconStyle}
-              />
-            </div>
-          ) : null
-        }
-      </Dialog>
-    );
+    switch (dialogType) {
+      case 'ARCHIVE_RETRO':
+        return (
+          <ArchiveRetroDialog
+            title={this.props.dialog.title}
+            message={this.props.dialog.message}
+            retro={this.props.retro}
+            featureFlags={this.props.featureFlags}
+            toggleSendArchiveEmail={this.props.toggleSendArchiveEmail}
+            archiveRetro={this.props.archiveRetro}
+            onClose={this.props.hideDialog}
+          />
+        );
+      case 'SHARE_RETRO':
+        return (
+          <ShareRetroDialog
+            retro={this.props.retro}
+            retroId={this.props.retroId}
+            onClose={this.props.hideDialog}
+          />
+        );
+      default:
+        return null;
+    }
   }
 
   renderMobile(retro) {
@@ -332,7 +299,7 @@ class ShowRetroPage extends React.Component {
     return (
       <span>
         <RetroWebsocket url={websocketUrl(config)} retro_id={retroId} websocketRetroDataReceived={this.props.websocketRetroDataReceived}/>
-        {this.renderArchiveConfirmationDialog()}
+        {this.renderDialog()}
         <div className={archives ? 'mobile-display archived' : 'mobile-display'}>
 
           <RetroLegalBanner retroId={retroId} isPrivate={retro.is_private} config={config}/>
@@ -405,7 +372,7 @@ class ShowRetroPage extends React.Component {
       <HotKeys keyMap={keyMap} handlers={keyHandlers}>
         <span>
           <RetroWebsocket url={websocketUrl(config)} retro_id={retroId} websocketRetroDataReceived={this.props.websocketRetroDataReceived}/>
-          {this.renderArchiveConfirmationDialog()}
+          {this.renderDialog()}
           <div className={retroContainerClasses}>
 
             <RetroLegalBanner retroId={retroId} isPrivate={retro.is_private} config={config}/>

--- a/web/src/components/retro-show/show_retro_page.test.jsx
+++ b/web/src/components/retro-show/show_retro_page.test.jsx
@@ -38,6 +38,8 @@ import goof from '../../test_support/test_doubles/goof';
 
 import {ShowRetroPage} from './show_retro_page';
 import RetroWebsocket from './retro_websocket';
+import ArchiveRetroDialog from './archive_retro_dialog';
+import ShareRetroDialog from './share_retro_dialog';
 
 const config = {
   title: 'Retro',
@@ -83,7 +85,6 @@ function UnconnectedShowRetroPage(props) {
       getRetro={jest.fn()}
       nextRetroItem={jest.fn()}
       archiveRetro={jest.fn()}
-      hideDialog={jest.fn()}
       getRetroArchive={jest.fn()}
       toggleSendArchiveEmail={jest.fn()}
       routeToRetroArchives={jest.fn()}
@@ -91,6 +92,7 @@ function UnconnectedShowRetroPage(props) {
       requireRetroLogin={jest.fn()}
       showDialog={jest.fn()}
       signOut={jest.fn()}
+      hideDialog={goof}
       voteRetroItem={goof}
       doneRetroItem={goof}
       undoneRetroItem={goof}
@@ -207,7 +209,7 @@ describe('ShowRetroPage', () => {
       expect(dom.find('.retro-back')).not.toExist();
     });
 
-    it('displays a dialog if requested', () => {
+    it('displays the archive dialog if requested', () => {
       dom = mount((
         <MuiThemeProvider>
           <UnconnectedShowRetroPage
@@ -218,27 +220,17 @@ describe('ShowRetroPage', () => {
             dialog={{
               title: 'Some dialog title',
               message: 'Some dialog message',
+              type: 'ARCHIVE_RETRO',
             }}
             featureFlags={{archiveEmails: true}}
             environment={environment}
           />
         </MuiThemeProvider>
       ));
-      const dialog = dom.find(Dialog);
-
-      expect(dialog).toHaveProp({open: true});
-      expect(dialog).toHaveProp({title: 'Some dialog title'});
-
-      // Dialog renders outside usual flow, so must use hacks:
-      const popupDialog = document.getElementsByClassName('archive-dialog')[0];
-
-      expect(popupDialog.querySelector('h3').innerHTML).toEqual('Some dialog title');
-      expect(popupDialog.querySelector('p').innerHTML).toEqual('Some dialog message');
-      expect(popupDialog.querySelector('div label').innerHTML).toEqual('Send action items to the team via email?');
+      expect(dom.find(ArchiveRetroDialog)).toExist();
     });
 
-    it('hides the dialog when requested', () => {
-      const hideDialog = jest.fn();
+    it('displays the share retro dialog if requested', () => {
       dom = mount((
         <MuiThemeProvider>
           <UnconnectedShowRetroPage
@@ -247,23 +239,18 @@ describe('ShowRetroPage', () => {
             archives={false}
             config={config}
             dialog={{
-              title: 'Some dialog title',
-              message: 'Some dialog message',
+              type: 'SHARE_RETRO',
             }}
             featureFlags={{archiveEmails: true}}
             environment={environment}
-            hideDialog={hideDialog}
           />
         </MuiThemeProvider>
       ));
-      const dialog = dom.find(Dialog);
-
-      dialog.props().onRequestClose();
-      expect(hideDialog).toHaveBeenCalled();
+      expect(dom.find(ShareRetroDialog)).toExist();
     });
 
-    it('does not display a dialog by default', () => {
-      expect(dom.find(Dialog)).toHaveProp({open: false});
+    it('does not display any dialog by default', () => {
+      expect(dom.find(Dialog)).not.toExist();
     });
 
     it('passes the retro URL to RetroWebsocket', () => {

--- a/web/src/components/router.jsx
+++ b/web/src/components/router.jsx
@@ -48,6 +48,7 @@ import {ConnectedListRetroArchivesPage} from './retro-archives/list_retro_archiv
 import Alert from './shared/alert';
 import {ConnectedRegistrationPage} from './registration/registration_page';
 import {clearAlert} from '../redux/actions/main_actions';
+import {joinRetro} from '../redux/actions/api_actions';
 
 
 class Router extends React.Component {
@@ -57,6 +58,7 @@ class Router extends React.Component {
     alert: types.object,
     not_found: types.object,
     clearAlert: types.func.isRequired,
+    joinRetro: types.func.isRequired,
   };
 
   static defaultProps = {
@@ -76,6 +78,7 @@ class Router extends React.Component {
     router.get('*', this.showNotFound);
     router.get('/', this.showHome);
     router.get('/retros/:retroId', this.showRetro);
+    router.get('/retros/:retroId/join/:joinToken', this.joinRetro);
     router.get('/retros/:retroId/archives', this.listRetroArchives);
     router.get('/retros/:retroId/archives/:archiveId', this.showRetroArchive);
     router.get('/retros/:retroId/login', this.loginToRetro);
@@ -117,6 +120,11 @@ class Router extends React.Component {
     }
 
     this.setPage(ConnectedShowRetroPage, {retroId, archives: false});
+  };
+
+  joinRetro = (req) => {
+    const {retroId, joinToken} = req.params;
+    this.props.joinRetro(retroId, joinToken);
   };
 
   listRetros = () => {
@@ -199,6 +207,7 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = (dispatch) => ({
   clearAlert: () => dispatch(clearAlert()),
+  joinRetro: (retroId, joinToken) => dispatch(joinRetro(retroId, joinToken)),
 });
 
 const ConnectedRouter = connect(mapStateToProps, mapDispatchToProps)(Router);

--- a/web/src/components/router.test.jsx
+++ b/web/src/components/router.test.jsx
@@ -47,7 +47,8 @@ describe('Router', () => {
     const fakeRouter = {get: () => {}};
 
     clearAlert = jest.fn();
-    rendered = shallow(<Router alert={{}} clearAlert={clearAlert} router={fakeRouter} config={{}}/>);
+
+    rendered = shallow(<Router alert={{}} clearAlert={clearAlert} router={fakeRouter} joinRetro={jest.fn()} config={{}}/>);
   });
 
   it('renders alert', () => {

--- a/web/src/redux/actions/api_actions.js
+++ b/web/src/redux/actions/api_actions.js
@@ -37,6 +37,10 @@ const getRetro = (id) => ({
   type: 'GET_RETRO',
   payload: id,
 });
+const joinRetro = (retroId, joinToken) => ({
+  type: 'JOIN_RETRO',
+  payload: {retroId, joinToken},
+});
 const getRetroSettings = (id) => ({
   type: 'GET_RETRO_SETTINGS',
   payload: id,
@@ -125,9 +129,9 @@ const createSession = (accessToken, email, name) => ({
   type: 'CREATE_SESSION',
   payload: {accessToken, email, name},
 });
-const updateRetroSettings = (retroId, retroName, newSlug, oldSlug, isPrivate, requestUuid, videoLink) => ({
+const updateRetroSettings = (retroId, retroName, newSlug, oldSlug, isPrivate, requestUuid, videoLink, isMagicLinkEnabled) => ({
   type: 'UPDATE_RETRO_SETTINGS',
-  payload: {retroId, retroName, newSlug, oldSlug, isPrivate, requestUuid, videoLink},
+  payload: {retroId, retroName, newSlug, oldSlug, isPrivate, requestUuid, videoLink, isMagicLinkEnabled},
 });
 const updateRetroPassword = (retroId, currentPassword, newPassword, requestUuid) => ({
   type: 'UPDATE_RETRO_PASSWORD',
@@ -141,6 +145,7 @@ const retrieveConfig = () => ({
 export {
   retroCreate,
   getRetro,
+  joinRetro,
   getRetroSettings,
   getRetroLogin,
   loginToRetro,

--- a/web/src/redux/middleware/archive_retro_middleware.js
+++ b/web/src/redux/middleware/archive_retro_middleware.js
@@ -53,6 +53,7 @@ const ArchiveMiddleware = () => (store) => (next) => (action) => {
         payload: {
           title: 'Archive this retro?',
           message: 'The board will be cleared ready for your next retro and incomplete action items will be carried across.',
+          type: 'ARCHIVE_RETRO',
         },
       });
     }

--- a/web/src/redux/middleware/archive_retro_middleware.test.js
+++ b/web/src/redux/middleware/archive_retro_middleware.test.js
@@ -83,6 +83,7 @@ describe('ArchiveMiddleware', () => {
       payload: {
         title: 'Archive this retro?',
         message: 'The board will be cleared ready for your next retro and incomplete action items will be carried across.',
+        type: 'ARCHIVE_RETRO',
       },
     });
   });

--- a/web/src/redux/reducers/retro_reducer.js
+++ b/web/src/redux/reducers/retro_reducer.js
@@ -36,6 +36,7 @@ const initialState = {
     action_items: [],
     is_private: false,
     send_archive_email: true,
+    join_token: null,
   },
   retroArchives: [],
   currentArchivedRetro: {
@@ -45,6 +46,7 @@ const initialState = {
     action_items: [],
     is_private: false,
     send_archive_email: true,
+    join_token: null,
   },
   retros: [],
 };

--- a/web/src/redux/reducers/retro_reducer.test.jsx
+++ b/web/src/redux/reducers/retro_reducer.test.jsx
@@ -52,6 +52,7 @@ describe('RetroReducer', () => {
         action_items: [],
         is_private: false,
         send_archive_email: true,
+        join_token: null,
       },
       retroArchives: [],
       currentArchivedRetro: {
@@ -61,6 +62,7 @@ describe('RetroReducer', () => {
         action_items: [],
         is_private: false,
         send_archive_email: true,
+        join_token: null,
       },
       retros: [],
     });
@@ -75,6 +77,7 @@ describe('RetroReducer', () => {
         action_items: [{}],
         is_private: true,
         send_archive_email: false,
+        join_token: 'join-token',
       };
 
       const action = {
@@ -167,6 +170,7 @@ describe('RetroReducer', () => {
         action_items: [{}],
         is_private: true,
         send_archive_email: false,
+        join_token: 'join-token',
       };
 
       const uniqueItem = {id: 3, category: 'happy'};
@@ -190,6 +194,7 @@ describe('RetroReducer', () => {
         action_items: [{}],
         is_private: true,
         send_archive_email: false,
+        join_token: 'join-token',
       };
 
       const uppdatedItem = {item: {id: 2, category: 'meh'}};
@@ -215,6 +220,7 @@ describe('RetroReducer', () => {
           is_private: true,
           send_archive_email: false,
           highlighted_item_id: 2,
+          join_token: 'join-token',
         };
 
         const uniqueAction = {
@@ -241,6 +247,7 @@ describe('RetroReducer', () => {
         is_private: true,
         send_archive_email: false,
         highlighted_item_id: 2,
+        join_token: 'join-token',
       };
 
       const newActionItem = {id: 2, description: 'new description', done: false};
@@ -266,6 +273,7 @@ describe('RetroReducer', () => {
         is_private: true,
         send_archive_email: false,
         highlighted_item_id: 2,
+        join_token: 'join-token',
       };
 
       const action = {
@@ -290,6 +298,7 @@ describe('RetroReducer', () => {
         is_private: true,
         send_archive_email: false,
         highlighted_item_id: 2,
+        join_token: 'join-token',
       };
 
       const action = {
@@ -342,6 +351,7 @@ describe('RetroReducer', () => {
         action_items: [{}],
         is_private: true,
         send_archive_email: false,
+        join_token: 'join-token',
       };
 
       const action = {

--- a/web/src/setupTests.js
+++ b/web/src/setupTests.js
@@ -29,29 +29,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-// SASS variable overrides must be declared before loading up Active Admin's styles.
-//
-// To view the variables that Active Admin provides, take a look at
-// `app/assets/stylesheets/active_admin/mixins/_variables.scss` in the
-// Active Admin source.
-//
-// For example, to change the sidebar width:
-// $sidebar-width: 242px;
 
-// Active Admin's got SASS!
-@import "active_admin/mixins";
-@import "active_admin/base";
+/* eslint-disable no-alert, no-console */
+const error = console.error;
 
-// Overriding any non-variable SASS must be done after the fact.
-// For example, to change the default status-tag color:
-//
-//   .status_tag { background: #6090DB; }
+console.error = (...args) => {
+  const message = args[0];
+  error.apply(console, args); // keep default behaviour
+  throw (message instanceof Error ? message : new Error(message));
+};
 
-.checkbox-label {
-  display: inline;
-}
-
-.checkbox-description {
-  margin-bottom: .5rem;
-  padding-left: 1.5rem;
-}
+/* eslint-enable no-alert, no-console */

--- a/web/src/stylesheets/_app.scss
+++ b/web/src/stylesheets/_app.scss
@@ -622,11 +622,11 @@ ol ol > li:before {
   }
 }
 
-.archive-dialog {
+.archive-dialog, .share-dialog {
   max-width: 40rem !important;
 }
 
-.archive-dialog__actions {
+.archive-dialog__actions, .share-dialog__actions {
   padding-left: 24px !important;
   padding-right: 24px !important;
 }
@@ -642,6 +642,54 @@ ol ol > li:before {
       background-color: inherit;
       color: inherit;
     }
+  }
+}
+
+.share-dialog__actions button {
+  @extend .button;
+
+  &.share-dialog__actions--close {
+    background-color: white;
+    color: $black;
+
+    &:hover {
+      background-color: inherit;
+      color: inherit;
+    }
+  }
+}
+
+.share-dialog {
+  .share-retro-url-wrapper {
+    font-size: 1.5rem;
+    position: relative;
+
+    input {
+      margin-bottom: 0;
+      margin-top: 1rem;
+      background-color: transparent;
+      border: 2px solid $lighter-gray;
+      padding-right: 3rem;
+      border-radius: 0.3rem;
+    }
+
+    .share-retro-url-copy {
+      position: absolute;
+      right: 0;
+      top: 0;
+      padding: 0.5rem 1rem 0;
+      color: $normal-gray;
+      text-align: right;
+
+      &:hover {
+        color: $highlight;
+        cursor: pointer;
+      }
+    }
+  }
+
+  .share-dialog__actions {
+    padding-top: 0 !important;
   }
 }
 


### PR DESCRIPTION
* A short explanation of the proposed change:
Add share retro functionality to be able to join any retro even protected ones with a magic link.

* An explanation of the use cases your change solves
Participants no longer need to know or remember the password in order to join retros.

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
