### PR TITLE
Refactor magic link code

### DIFF
--- a/api/app/admin/retros.rb
+++ b/api/app/admin/retros.rb
@@ -127,23 +127,13 @@ ActiveAdmin.register Retro do
   form do |f|
     f.semantic_errors
 
-    private_label =  '<strong> Make this retro private? </strong> ' +
-      '<p class="checkbox-description">A private retro requires a password to access. A public retro can be accessed by anyone.</p> '
-
-    magic_link_label = '<strong> Share this retro using a magic link? </strong>' +
-      '<p class="checkbox-description"> This will provide a magic link that allows users to access' +
-      ' this retro without being prompted for a password. This is not the same as making a retro public.</p>'
-
     f.inputs 'Details' do
       f.input :name
       f.input :slug
       f.input :video_link
-      f.input :owner_email, label: 'Owner Email'
-      f.input :is_private,
-              label: simple_format(private_label, { class: 'checkbox-label'} )
-      f.input :magic_link_enabled,
-              as: :boolean,
-              label: simple_format(magic_link_label, { class: 'checkbox-label'} )
+      f.input :owner_email
+      f.input :is_private
+      f.input :magic_link_enabled, as: :boolean
     end
 
     f.inputs do

--- a/api/app/admin/retros.rb
+++ b/api/app/admin/retros.rb
@@ -133,13 +133,17 @@ ActiveAdmin.register Retro do
     magic_link_label = '<strong> Share this retro using a magic link? </strong>' +
       '<p class="checkbox-description"> This will provide a magic link that allows users to access' +
       ' this retro without being prompted for a password. This is not the same as making a retro public.</p>'
+
     f.inputs 'Details' do
       f.input :name
       f.input :slug
       f.input :video_link
       f.input :owner_email, label: 'Owner Email'
-      f.input :is_private, label: simple_format(private_label, { class: 'checkbox-label'} )
-      f.input :magic_link_enabled?, label: simple_format(magic_link_label, { class: 'checkbox-label'} ) , as: :boolean, input_html: { checked: f.object.magic_link_enabled? }
+      f.input :is_private,
+              label: simple_format(private_label, { class: 'checkbox-label'} )
+      f.input :magic_link_enabled,
+              as: :boolean,
+              label: simple_format(magic_link_label, { class: 'checkbox-label'} )
     end
 
     f.inputs do
@@ -184,9 +188,6 @@ ActiveAdmin.register Retro do
       if params['retro']['remove_password'] && params['retro']['remove_password'][1] == 'Remove'
         params[:retro][:encrypted_password] = nil
       end
-
-      params[:retro][:is_magic_link_enabled] = params['retro']['magic_link_enabled?'] == "1"
-      params[:retro].delete('magic_link_enabled?')
 
       params[:retro].delete('remove_password')
       update!

--- a/api/app/assets/stylesheets/active_admin.scss
+++ b/api/app/assets/stylesheets/active_admin.scss
@@ -47,11 +47,6 @@
 //
 //   .status_tag { background: #6090DB; }
 
-.checkbox-label {
-  display: inline;
-}
-
-.checkbox-description {
-  margin-bottom: .5rem;
-  padding-left: 1.5rem;
+form fieldset > ol > li.boolean label {
+  font-weight: bold;
 }

--- a/api/app/assets/stylesheets/active_admin.scss
+++ b/api/app/assets/stylesheets/active_admin.scss
@@ -40,6 +40,9 @@
 
 // Active Admin's got SASS!
 @import "active_admin/mixins";
+
+$text-input-total-padding: $text-input-total-padding + 2px;
+
 @import "active_admin/base";
 
 // Overriding any non-variable SASS must be done after the fact.

--- a/api/app/models/retro.rb
+++ b/api/app/models/retro.rb
@@ -70,11 +70,9 @@ class Retro < ActiveRecord::Base
     val == join_token
   end
 
-  def is_magic_link_enabled=(val)
-    if ActiveModel::Type::Boolean.new.cast(val)
-      unless join_token.nil?
-        return
-      end
+  def magic_link_enabled=(val)
+    if val.present?
+      return if magic_link_enabled?
 
       recompute_join_token
     else
@@ -82,9 +80,12 @@ class Retro < ActiveRecord::Base
     end
   end
 
-  def magic_link_enabled?
-    !join_token.nil?
+  def magic_link_enabled
+    join_token?
   end
+
+  alias magic_link_enabled? magic_link_enabled
+  alias_attribute :is_magic_link_enabled, :magic_link_enabled
 
   def create_instruction_cards!
     I18n.t('instruction_cards.items').each do |category, descriptions|

--- a/api/app/models/retro.rb
+++ b/api/app/models/retro.rb
@@ -85,6 +85,9 @@ class Retro < ActiveRecord::Base
   end
 
   alias magic_link_enabled? magic_link_enabled
+
+  # aliasing this in order to limit changes required to API
+  # TODO: change API and front end to refer to this key as just 'magic_link_enabled'
   alias_attribute :is_magic_link_enabled, :magic_link_enabled
 
   def create_instruction_cards!

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -68,6 +68,17 @@ en:
     actions: ["Tick off action items when complete (Owner's Name)",
       "Add action items with a single owner (Owner’s Name)"]
 
+  formtastic:
+    labels:
+      retro:
+        is_private: "Make this retro private?"
+        magic_link_enabled: "Share this retro using a magic link?"
+        owner_email: "Owner Email"
+    hints:
+      retro:
+        is_private: "A private retro requires a password to access. A public retro can be accessed by anyone."
+        magic_link_enabled: "This will provide a magic link that allows users to access this retro without being prompted for a password. This is not the same as making a retro public."
+
   activerecord:
     errors:
       models:

--- a/api/spec/model/retro_spec.rb
+++ b/api/spec/model/retro_spec.rb
@@ -82,6 +82,20 @@ describe Retro do
     end
   end
 
+  describe '#magic_link_enabled' do
+    it 'behaves like a boolean' do
+      retro = Retro.new
+
+      2.times do
+        retro.magic_link_enabled = true
+        expect(retro.magic_link_enabled).to eq(true)
+
+        retro.magic_link_enabled = false
+        expect(retro.magic_link_enabled).to eq(false)
+      end
+    end
+  end
+
   context 'retro has magic link enabled' do
     let(:retro) do
       Retro.create!(


### PR DESCRIPTION
* A short explanation of the proposed change:

Refactored / standardized a bit of the Rails code that provides magic link support.

Some crazy `formtastic` config options for labels and hints was buried in my brain, and has now become unstuck 😬.

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
