### PR TITLE
Enable Postgres ActionCable adapter via environment variable

### DIFF
--- a/api/config/cable.yml
+++ b/api/config/cable.yml
@@ -35,5 +35,4 @@ test:
   adapter: test
 
 production:
-  adapter: redis
-  url: <%= RedisConfigurationProvider.new.redis_config %>
+  <%= ActionCableAdapterConfigurationProvider.new.cable_config %>

--- a/api/lib/configurations/action_cable_adapter_configuration_provider.rb
+++ b/api/lib/configurations/action_cable_adapter_configuration_provider.rb
@@ -1,0 +1,30 @@
+require 'configurations/redis_configuration_provider'
+
+class ActionCableAdapterConfigurationProvider
+  def cable_config
+    if use_postgres_as_adapter?
+      postgres_adapter
+    else
+      redis_adapter
+    end.to_json
+  end
+
+  private
+
+  def use_postgres_as_adapter?
+    ENV['USE_POSTGRES_FOR_ACTION_CABLE'] == 'true'
+  end
+
+  def postgres_adapter
+    {
+      adapter: 'postgresql'
+    }
+  end
+
+  def redis_adapter
+    {
+      adapter: 'redis',
+      url: RedisConfigurationProvider.new.redis_config
+    }
+  end
+end

--- a/api/spec/lib/action_cable_adapter_configuration_provider_spec.rb
+++ b/api/spec/lib/action_cable_adapter_configuration_provider_spec.rb
@@ -1,0 +1,49 @@
+require 'configurations/action_cable_adapter_configuration_provider'
+require 'climate_control'
+
+describe ActionCableAdapterConfigurationProvider do
+  let(:fake_redis_url) { 'fake-redis-url' }
+
+  subject { ActionCableAdapterConfigurationProvider.new }
+
+  around do |example|
+    ClimateControl.modify('REDIS_URL' => fake_redis_url, 'RAILS_ENV' => 'production') do
+      example.run
+    end
+  end
+
+  describe 'when USE_POSTGRES_FOR_ACTION_CABLE is not set' do
+    it 'returns the redis configuration' do
+      config = subject.cable_config
+      expect(JSON.parse(config)['adapter']).to eq('redis')
+      expect(JSON.parse(config)['url']).to eq(fake_redis_url)
+    end
+  end
+
+  describe 'when USE_POSTGRES_FOR_ACTION_CABLE is set' do
+    around do |example|
+      ClimateControl.modify('USE_POSTGRES_FOR_ACTION_CABLE' => use_postgres_for_action_cable_env) do
+        example.run
+      end
+    end
+
+    context 'to true' do
+      let(:use_postgres_for_action_cable_env) { 'true' }
+      it 'returns the adapter as postgresql with no url' do
+        config = subject.cable_config
+        expect(JSON.parse(config)['adapter']).to eq('postgresql')
+        expect(JSON.parse(config)['url']).to be_nil
+      end
+    end
+
+    context 'to false' do
+      let(:use_postgres_for_action_cable_env) { 'false' }
+
+      it 'returns the redis configuration' do
+        config = subject.cable_config
+        expect(JSON.parse(config)['adapter']).to eq('redis')
+        expect(JSON.parse(config)['url']).to eq(fake_redis_url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* A short explanation of the proposed change:

This change enables someone to configure Postfacto to use Postgres as the ActionCable, which would allow that deployment to no longer require a redis instance.

The environment variable required is:
```
USE_POSTGRES_FOR_ACTION_CABLE=true
```

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
