### PR TITLE
Magic link analytics

### DIFF
--- a/web/src/components/retro-show/retro_heading.jsx
+++ b/web/src/components/retro-show/retro_heading.jsx
@@ -46,6 +46,7 @@ export default class RetroHeading extends React.Component {
     requireRetroLogin: types.func.isRequired,
     showDialog: types.func.isRequired,
     signOut: types.func.isRequired,
+    viewedMagicLink: types.func.isRequired,
   };
 
   constructor(props) {
@@ -106,6 +107,7 @@ export default class RetroHeading extends React.Component {
   }
 
   handleShareRetro() {
+    this.props.viewedMagicLink(this.props.retroId);
     this.props.showDialog({
       type: 'SHARE_RETRO',
     });

--- a/web/src/components/retro-show/retro_heading.test.jsx
+++ b/web/src/components/retro-show/retro_heading.test.jsx
@@ -59,6 +59,7 @@ function createShallowRetroHeading(retroOverrides = {}, propOverrides = {}) {
     requireRetroLogin={jest.fn()}
     showDialog={jest.fn()}
     signOut={jest.fn()}
+    viewedMagicLink={jest.fn()}
     {...propOverrides}
   />);
 }
@@ -150,6 +151,18 @@ describe('RetroHeading', () => {
       expect(showDialog).toHaveBeenCalledWith({
         type: 'SHARE_RETRO',
       });
+    });
+
+    it('invokes viewedMagicLink when the share button is clicked', () => {
+      const viewedMagicLink = jest.fn();
+      const dom = createShallowRetroHeading({
+        join_token: 'join-token',
+        items: [],
+      }, {viewedMagicLink});
+
+      dom.find('.share-button').simulate('click');
+
+      expect(viewedMagicLink).toHaveBeenCalledWith('13');
     });
   });
 

--- a/web/src/components/retro-show/share_retro_dialog.jsx
+++ b/web/src/components/retro-show/share_retro_dialog.jsx
@@ -40,6 +40,7 @@ export default class ShareRetroDialog extends React.Component {
       join_token: types.string,
     }).isRequired,
     onClose: types.func.isRequired,
+    copiedMagicLink: types.func.isRequired,
   };
 
   constructor(props) {
@@ -55,6 +56,7 @@ export default class ShareRetroDialog extends React.Component {
     textToCopy.setSelectionRange(0, 99999); /* For mobile devices */
 
     document.execCommand('copy');
+    this.props.copiedMagicLink(this.props.retroId);
   }
 
   render() {

--- a/web/src/components/retro-show/share_retro_dialog.test.jsx
+++ b/web/src/components/retro-show/share_retro_dialog.test.jsx
@@ -40,11 +40,12 @@ function mountShareRetroDialog(props) {
   return mount((
     <MuiThemeProvider>
       <ShareRetroDialog
-        retroId="my-retro"
+        retroId='my-retro'
         retro={{
           join_token: null,
         }}
         onClose={jest.fn()}
+        copiedMagicLink={jest.fn()}
         {...props}
       />
     </MuiThemeProvider>
@@ -62,6 +63,16 @@ describe('ShareRetroDialog', () => {
     mountShareRetroDialog();
     getDialogElement().querySelector('.share-retro-url-copy').click();
     expect(document.execCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('invokes copiedMagicLink when the copy button is clicked', async () => {
+    document.execCommand = jest.fn();
+    const copiedMagicLink = jest.fn();
+    mountShareRetroDialog({
+      copiedMagicLink
+    });
+    getDialogElement().querySelector('.share-retro-url-copy').click();
+    expect(copiedMagicLink).toHaveBeenCalledWith('my-retro');
   });
 
   it('invokes onClose when the close button is clicked', () => {

--- a/web/src/components/retro-show/share_retro_dialog.test.jsx
+++ b/web/src/components/retro-show/share_retro_dialog.test.jsx
@@ -40,7 +40,7 @@ function mountShareRetroDialog(props) {
   return mount((
     <MuiThemeProvider>
       <ShareRetroDialog
-        retroId='my-retro'
+        retroId="my-retro"
         retro={{
           join_token: null,
         }}
@@ -69,7 +69,7 @@ describe('ShareRetroDialog', () => {
     document.execCommand = jest.fn();
     const copiedMagicLink = jest.fn();
     mountShareRetroDialog({
-      copiedMagicLink
+      copiedMagicLink,
     });
     getDialogElement().querySelector('.share-retro-url-copy').click();
     expect(copiedMagicLink).toHaveBeenCalledWith('my-retro');

--- a/web/src/components/retro-show/show_retro_page.jsx
+++ b/web/src/components/retro-show/show_retro_page.jsx
@@ -74,6 +74,10 @@ import {retroArchives, retroLogin, retroSettings} from '../../redux/actions/rout
 import {websocketUrl} from '../../helpers/websockets';
 import ArchiveRetroDialog from './archive_retro_dialog';
 import ShareRetroDialog from './share_retro_dialog';
+import {
+  copiedMagicLink,
+  viewedMagicLink
+} from "../../redux/actions/analytics_actions";
 
 function getItemArchiveTime(item) {
   if (!item.archived_at) {
@@ -122,6 +126,7 @@ class ShowRetroPage extends React.Component {
     doneRetroActionItem: types.func.isRequired,
     deleteRetroActionItem: types.func.isRequired,
     editRetroActionItem: types.func.isRequired,
+    viewedMagicLink: types.func.isRequired,
     extendTimer: types.func.isRequired,
     websocketRetroDataReceived: types.func.isRequired,
   };
@@ -286,6 +291,7 @@ class ShowRetroPage extends React.Component {
             retro={this.props.retro}
             retroId={this.props.retroId}
             onClose={this.props.hideDialog}
+            copiedMagicLink={this.props.copiedMagicLink}
           />
         );
       default:
@@ -314,6 +320,7 @@ class ShowRetroPage extends React.Component {
             requireRetroLogin={this.props.requireRetroLogin}
             showDialog={this.props.showDialog}
             signOut={this.props.signOut}
+            viewedMagicLink={this.props.viewedMagicLink}
           />
 
           <div className="mobile-tabs">
@@ -387,6 +394,7 @@ class ShowRetroPage extends React.Component {
               requireRetroLogin={this.props.requireRetroLogin}
               showDialog={this.props.showDialog}
               signOut={this.props.signOut}
+              viewedMagicLink={this.props.viewedMagicLink}
             />
             <div className="retro-item-list">
               <RetroColumn
@@ -505,6 +513,8 @@ const mapDispatchToProps = (dispatch) => ({
   doneRetroActionItem: (retroId, actionItemId, done) => dispatch(doneRetroActionItem(retroId, actionItemId, done)),
   deleteRetroActionItem: (retroId, actionItem) => dispatch(deleteRetroActionItem(retroId, actionItem)),
   editRetroActionItem: (retroId, actionItemId, description) => dispatch(editRetroActionItem(retroId, actionItemId, description)),
+  viewedMagicLink: (retroId) => dispatch(viewedMagicLink(retroId)),
+  copiedMagicLink: (retroId) => dispatch(copiedMagicLink(retroId)),
   extendTimer: (retroId) => dispatch(extendTimer(retroId)),
   websocketRetroDataReceived: (data) => {
     if (data.command === 'force_relogin') {

--- a/web/src/components/retro-show/show_retro_page.jsx
+++ b/web/src/components/retro-show/show_retro_page.jsx
@@ -76,8 +76,8 @@ import ArchiveRetroDialog from './archive_retro_dialog';
 import ShareRetroDialog from './share_retro_dialog';
 import {
   copiedMagicLink,
-  viewedMagicLink
-} from "../../redux/actions/analytics_actions";
+  viewedMagicLink,
+} from '../../redux/actions/analytics_actions';
 
 function getItemArchiveTime(item) {
   if (!item.archived_at) {
@@ -127,6 +127,7 @@ class ShowRetroPage extends React.Component {
     deleteRetroActionItem: types.func.isRequired,
     editRetroActionItem: types.func.isRequired,
     viewedMagicLink: types.func.isRequired,
+    copiedMagicLink: types.func.isRequired,
     extendTimer: types.func.isRequired,
     websocketRetroDataReceived: types.func.isRequired,
   };

--- a/web/src/components/retro-show/show_retro_page.test.jsx
+++ b/web/src/components/retro-show/show_retro_page.test.jsx
@@ -105,6 +105,8 @@ function UnconnectedShowRetroPage(props) {
       createRetroActionItem={goof}
       doneRetroActionItem={goof}
       editRetroActionItem={goof}
+      viewedMagicLink={goof}
+      copiedMagicLink={goof}
       extendTimer={goof}
       websocketRetroDataReceived={goof}
       {...props}

--- a/web/src/components/retro-show/show_retro_page_archives.test.jsx
+++ b/web/src/components/retro-show/show_retro_page_archives.test.jsx
@@ -127,6 +127,8 @@ describe('Show retro page archives', () => {
             doneRetroActionItem={goof}
             deleteRetroActionItem={goof}
             editRetroActionItem={goof}
+            viewedMagicLink={goof}
+            copiedMagicLink={goof}
             extendTimer={goof}
             websocketRetroDataReceived={goof}
           />
@@ -200,6 +202,8 @@ describe('Show retro page archives', () => {
             doneRetroActionItem={goof}
             deleteRetroActionItem={goof}
             editRetroActionItem={goof}
+            viewedMagicLink={goof}
+            copiedMagicLink={goof}
             extendTimer={goof}
             websocketRetroDataReceived={goof}
           />

--- a/web/src/components/retro-show/show_retro_page_settings.test.jsx
+++ b/web/src/components/retro-show/show_retro_page_settings.test.jsx
@@ -98,6 +98,8 @@ describe('Retro settings', () => {
           doneRetroItem={goof}
           deleteRetroActionItem={goof}
           editRetroActionItem={goof}
+          viewedMagicLink={goof}
+          copiedMagicLink={goof}
           extendTimer={goof}
           websocketRetroDataReceived={goof}
         />

--- a/web/src/redux/actions/analytics_actions.js
+++ b/web/src/redux/actions/analytics_actions.js
@@ -17,6 +17,8 @@ const createdActionItem = (retroId) => event('Created Action Item', {'retroId': 
 const doneActionItem = (retroId) => event('Done Action Item', {'retroId': retroId});
 const undoneActionItem = (retroId) => event('Undone Action Item', {'retroId': retroId});
 const archivedRetro = (retroId) => event('Archived Retro', {'retroId': retroId});
+const viewedMagicLink = (retroId) => event('Viewed Magic Link', {'retroId': retroId});
+const copiedMagicLink = (retroId) => event('Copied Magic Link to Clipboard', {'retroId': retroId});
 const homePageShown = () => event('Loaded homepage');
 
 export {
@@ -28,5 +30,7 @@ export {
   doneActionItem,
   undoneActionItem,
   archivedRetro,
+  viewedMagicLink,
+  copiedMagicLink,
   homePageShown,
 };

--- a/web/src/redux/actions/analytics_actions.js
+++ b/web/src/redux/actions/analytics_actions.js
@@ -8,6 +8,7 @@ const event = (type, data) => ({
 
 const createdRetro = (retroId) => event('Created Retro', {'retroId': retroId});
 const visitedRetro = (retroId) => event('Retro visited', {'retroId': retroId});
+const visitedRetroMagicLink = (retroId) => event('Retro visited - Magic Link', {'retroId': retroId});
 const createdRetroItem = (retroId, category) => event('Created Retro Item', {'retroId': retroId, 'category': category});
 const completedRetroItem = (retroId, category) => event('Completed Retro Item', {
   'retroId': retroId,
@@ -24,6 +25,7 @@ const homePageShown = () => event('Loaded homepage');
 export {
   createdRetro,
   visitedRetro,
+  visitedRetroMagicLink,
   createdRetroItem,
   completedRetroItem,
   createdActionItem,

--- a/web/src/redux/middleware/api_middleware.js
+++ b/web/src/redux/middleware/api_middleware.js
@@ -48,7 +48,9 @@ import {
   createdRetro,
   createdRetroItem,
   doneActionItem,
-  undoneActionItem, visitedRetro,
+  undoneActionItem,
+  visitedRetro,
+  visitedRetroMagicLink,
 } from '../actions/analytics_actions';
 import {
   home,
@@ -186,6 +188,7 @@ const ApiMiddleware = (retroClient) => (store) => (next) => (action) => {
         const token = response.token;
         if (token) {
           setApiToken(retroId, token);
+          store.dispatch(visitedRetroMagicLink(retroId));
         }
       } else {
         clearApiToken(retroId);

--- a/web/src/redux/middleware/api_middleware.test.js
+++ b/web/src/redux/middleware/api_middleware.test.js
@@ -65,7 +65,9 @@ import {
   createdRetro,
   createdRetroItem,
   doneActionItem,
-  undoneActionItem, visitedRetro,
+  undoneActionItem,
+  visitedRetro,
+  visitedRetroMagicLink,
 } from '../actions/analytics_actions';
 import {
   home,
@@ -490,6 +492,7 @@ describe('ApiMiddleware', () => {
       expect(localStorage.getItem('apiToken-15')).toEqual('the-api-token');
 
       expect(store.dispatch).toHaveBeenCalledWith(showRetroForId(15));
+      expect(store.dispatch).toHaveBeenCalledWith(visitedRetroMagicLink(15));
     });
 
     it('clears the api token if the join token is rejected', () => {


### PR DESCRIPTION
* A short explanation of the proposed change:
  Add mixpanel analytics around the following events, as mentioned in #291:
  - Clicking on the 'Share' button (to view the Magic Link)
  - Using the copy to clipboard icon to copy the Magic Link
  - Successfully visiting a retro via the Magic Link

* An explanation of the use cases your change solves
  Being able to tell if/how our users are using the new Magic Link feature.

**Note:** this does not include tracking when the Magic Link has been enabled/disabled for a project, as that required more thinking about what to do when it is enabled via the admin panel (api), and events are not yet being sent to mixpanel from the api. We can make another issue for that

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
