### PR TITLE
Define rails env in run script so the api doesn't die when running locally

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -30,7 +30,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 set -e
 
-BASE_DIR="$(dirname "$0")"
+export BASE_DIR="$(dirname "$0")"
+export RAILS_ENV="development"
 
 # Parse configuration
 
@@ -60,8 +61,6 @@ pushd "$BASE_DIR/api" >/dev/null
   ADMIN_EMAIL="$ADMIN_USER" ADMIN_PASSWORD="$ADMIN_PASS" bundle exec rake admin:create_user
 popd >/dev/null
 
-export BASE_DIR
-export RAILS_ENV
 export USE_MOCK_GOOGLE
 export GOOGLE_OAUTH_CLIENT_ID
 


### PR DESCRIPTION
* A short explanation of the proposed change:
Set `RAILS_ENV` to `development` at the start of the script for running Postfacto locally.

* An explanation of the use cases your change solves
[This line ](https://github.com/pivotal/postfacto/blob/218d350bfd1bc0d6614d96bf92f39e7c63b783ea/run.sh#L74)in the _run.sh_ script was causing the API to die, meaning running the app locally didn't work, because it could not find a `RAILS_ENV`.

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
