### PR TITLE
RFC - Attempt at making deployment docs easier to follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,16 @@ Retros are designed to help teams improve and that's hard to do without taking a
 
 ## Deployment
 
-Postfacto is a self hosted product, this makes it easier for you to stay in control of your data. We aim to make it easy to deploy to as many locations as possible.
+Postfacto is a self hosted product, this makes it easier for you to stay in control of your data.
 
-First, download and extract the latest package from the [releases page](https://github.com/pivotal/postfacto/releases) before following the instructions below for your supported platform:
+We aim to make it easy to deploy to as many locations as possible, and currently support the following platforms:
 
-* [Tanzu Kubernetes Grid](deployment#tanzu-kubernetes-grid-vsphere)
-* [Tanzu Application Service](deployment/README.md#tanzu-application-service)
-* [Cloud Foundry](deployment/README.md#cloud-foundry)
-* [Heroku](deployment/README.md#heroku)
+* Tanzu Kubernetes Grid
+* Tanzu Application Service
+* Cloud Foundry
+* Heroku
+
+Deployment instructions can be found [here](deployment/README.md).
 
 If the platforms above don't work for you; you may be able to find a way to run Postfacto yourself by following the Contributing Guide.
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -5,7 +5,7 @@
 1. [Optional] Configure your deployment
       * [Add Google Auth](#allowing-users-to-create-retros)
       * [Enable analytics](#enabling-analytics)
-      * [Increasing the session timeout](#changing-session-timeout)
+      * [Increase the session timeout](#changing-session-timeout)
       * [Use TLS for database connections](#using-tls-for-database-connections)
       * [Deploy without Redis (only for v4.3.0 or higher with Postgres)](#removing-redis-dependency)
 1. Follow the instructions to deploy for your platform:

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -2,13 +2,14 @@
 
 1. Download and extract the latest package from the [releases page](https://github.com/pivotal/postfacto/releases)
 1. Choose a name for your app, we'll refer to this as `app-name` from now on
+1. [Configure your deployment](#configuration) by adding Google Auth, enabling analytics, increasing the session timeout or setting the environment variable to run without Redis (only for v4.3.0 or higher with Postgres)
 1. Follow the instructions to deploy for your platform:
       * [Tanzu Application Service](#tanzu-application-service)
       * [Tanzu Kubernetes Grid (vSphere)](#tanzu-kubernetes-grid-vsphere)
       * [Cloud Foundry](#cloud-foundry)
       * [Heroku](#heroku)
 1. [Test your deployment](#testing-your-deployment)
-1. [Configure your deployment](#configuration) by adding Google Auth, enabling analytics, increasing the session timeout and removing Redis (only for v4.3.0 or higher with Postgres)
+
 ## Tanzu Application Service
 
 #### Initial deployment

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,18 +1,14 @@
 # Deployment
 
-## Contents
-  * [Prerequisites](#prerequisites)
-  * [Tanzu Application Service](#tanzu-application-service)
-  * [Tanzu Kubernetes Grid (vSphere)](#tanzu-kubernetes-grid-vsphere)
-  * [Cloud Foundry](#cloud-foundry)
-  * [Heroku](#heroku)
-  * [Configuration](#configuration)
-  * [Testing your deployment](#testing-your-deployment)
-
-## Prerequisites
 1. Download and extract the latest package from the [releases page](https://github.com/pivotal/postfacto/releases)
-2. Choose a name for your app, we'll refer to this as `app-name` from now on
-
+1. Choose a name for your app, we'll refer to this as `app-name` from now on
+1. Follow the instructions to deploy for your platform:
+      * [Tanzu Application Service](#tanzu-application-service)
+      * [Tanzu Kubernetes Grid (vSphere)](#tanzu-kubernetes-grid-vsphere)
+      * [Cloud Foundry](#cloud-foundry)
+      * [Heroku](#heroku)
+1. [Test your deployment](#testing-your-deployment)
+1. [Configure your deployment](#configuration) by adding Google Auth, enabling analytics, increasing the session timeout and removing Redis (only for v4.3.0 or higher with Postgres)
 ## Tanzu Application Service
 
 #### Initial deployment


### PR DESCRIPTION
* A short explanation of the proposed change:
Remove the link to each specific platform from the main readme, and instead link to the top of the deployment readme. 

This is because people often miss the first instructions (download the package.zip from the releases page) as it is hidden in pre requisites at the top of the page.

This is a move to making it simpler, but I am not sure that it is the best way. Other options include:

- Replicating the  pre-requisites in each platform-specific section in one page
- Having a different readme page for each platform, and replicating the pre-requisites in each of those

* [X] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [X] I have made this pull request to the `master` branch

* [X] I have run all the tests using `./test.sh`.

* [X] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [ X] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
