### PR TITLE
Set heroku stack as heroku-18

### DIFF
--- a/deployment/deploy-heroku.sh
+++ b/deployment/deploy-heroku.sh
@@ -57,7 +57,7 @@ cp "$CONFIG_DIR/Procfile" "$ASSETS_DIR"
 ###################
 
 pushd "$ASSETS_DIR"
-  heroku create ${APP_HOST} --buildpack https://github.com/heroku/heroku-buildpack-ruby.git#v215 --region ${HEROKU_REGION}
+  heroku create ${APP_HOST} --buildpack https://github.com/heroku/heroku-buildpack-ruby.git#v215 --region ${HEROKU_REGION} --stack heroku-18
   heroku addons:create heroku-postgresql:hobby-dev -a ${APP_HOST}
   heroku addons:create heroku-redis:hobby-dev -a ${APP_HOST}
   heroku config:set WEBSOCKET_PORT=4443 SESSION_TIME=${SESSION_TIME} -a ${APP_HOST}

--- a/humans.txt
+++ b/humans.txt
@@ -61,3 +61,6 @@ Contact: mike.kenyon@gmail.com
 
 Engineer: Max Brauer
 Contact: github.com/mamachanko
+
+Engineer: Lenox Waciuma Wanjohi
+Contact: code@waciuma.com


### PR DESCRIPTION
This commit sets the stack to the older Heroku-18 stack, which allows
deployment on Heroku to succeed.

Postfacto currently depends on Ruby 2.6.3
Heroku's current stack does not support Ruby 2.6.3
https://devcenter.heroku.com/articles/ruby-support#ruby-versions

**Note** Tests run in the postfacto docker image against master and against this commit have the same pass/fail. (i.e. a failing test on master ./spec/felicity_journey_spec.rb:308)

Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [N/A] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
