### PR TITLE
Allow admin email and password to be overridden (fixes #369)

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,8 +1,9 @@
 # Deployment
 
-1. Download and extract the latest package from the [releases page](https://github.com/pivotal/postfacto/releases)
+1. Download and extract the latest `package.zip` from the [releases page](https://github.com/pivotal/postfacto/releases)
 1. Choose a name for your app, we'll refer to this as `app-name` from now on
-1. [Optional] Configure your deployment
+1. _[Strongly recommended]_ Choose an admin email and password to override the defaults (`email@example.com` and `password` respectively), we'll refer to these as `admin-email` and `admin-password` from now on
+1. _[Optional]_ Configure your deployment:
       * [Add Google Auth](#allowing-users-to-create-retros)
       * [Enable analytics](#enabling-analytics)
       * [Increase the session timeout](#changing-session-timeout)
@@ -21,16 +22,16 @@
 
 In order for users to sign-up and create their own retros using the web UI, Postfacto needs Google OAuth setup.
 For deployments that do not want to setup Google OAuth, you will need to create your retros through the admin console of your server via
-`<app-name>.cfapps.io/admin` or `<app-name>.<cf-url>/admin`.
+`<app-name>.<cf-url>/admin`
 
 1. Go to [Google Cloud Console](https://console.cloud.google.com) and
    create a new project
 1. Go to APIs & Services > Credentials > Create Credentials > OAuth client ID > Web application
 1. Choose a name for your app
-1. In `Authorized JavaScript Origins`, set it to the public URL of your `app-name`. For example: if deploying to Heroku, your public URL will be `https://<app-name>.herokuapp.com`.
+1. In `Authorized JavaScript Origins`, set it to the public URL of your `app-name`. For example: if deploying to Heroku, your public URL will be `https://<app-name>.herokuapp.com`
 1. You can leave redirect blank
 1. Take note of your `client-id` that is generated
-1. Add `"google_oauth_client_id": {{client-id}}` to the `config.js` for your installation.
+1. Add `"google_oauth_client_id": {{client-id}}` to the `config.js` for your installation
 
 ### Enabling analytics
 
@@ -41,7 +42,7 @@ If you'd like to have your instance send analytics data to the Postfacto team so
 You can customise this window with the `SESSION_TIME` env variable to the `env` on deploy. To set a session time of 1 hour for example:
 
 ```bash
-SESSION_TIME=60 ./deploy <app-name>
+SESSION_TIME=60 ./deploy.sh <app-name>
 ```
 
 ### Using TLS for database connections
@@ -77,19 +78,27 @@ More information about SSL modes can be found [here](https://www.postgresql.org/
 ### Removing Redis dependency
 If you are on a **later version than 4.3.0** and using Postgres, Redis is no longer required. Instead set the environment variable `USE_POSTGRES_FOR_ACTION_CABLE=true` on deploy.
 
+However, note that for larger retros the live websocket updates may stop working (see [#346](https://github.com/pivotal/postfacto/issues/346)) as the Postgres adapter has an 8kB payload limit.
+
 ## Tanzu Application Service
 
 #### Initial deployment
 
-1. Set yourself up with an organization and space in your TAS account to deploy Postfacto to.
-1. Add a database (Postgres or Mysql) and a Redis service instance to your space from the Marketplace. Name these services `postfacto-db` and `postfacto-redis`.
-1. Run the TAS deployment script from the `tas` directory:
+1. Set yourself up with an organization and space in your TAS account to deploy Postfacto to
+1. Add a database (Postgres or MySQL) and a Redis service instance to your space from the Marketplace. Name these services `postfacto-db` and `postfacto-redis`
+1. Run the TAS deployment script from the `tas` directory, either:
+
+    ```bash
+    ADMIN_EMAIL=<admin-email> ADMIN_PASSWORD=<admin-password> ./deploy.sh <app-name>
+    ```
+
+    or, to use the default admin credentials (`email@example.com` and `password`):
 
     ```bash
     ./deploy.sh <app-name>
     ```
 
-   Take note of the URL that has shown up in the `routes:` section of the script output, going forward referred to as `<app-url>`.
+   Take note of the URL that has shown up in the `routes:` section of the script output, going forward referred to as `<app-url>`
 1. Log in to the Postfacto admin dashboard (email: `email@example.com` and password: `password`) to check everything has worked at `<app-url>/admin`
 1. Create a retro for yourself by clicking on 'Retros' and the 'New Retro'
 1. Log in to your retro at `<app-url>/retros/your-retro-slug`
@@ -117,11 +126,18 @@ If you are on a **later version than 4.3.0** and using Postgres, Redis is no lon
 1. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) to your local machine
 1. Install [helm](https://helm.sh/docs/intro/install/) to your local machine
 1. Make sure `kubectl` is configured to connect to the TKG cluster (ask your administrator for the configuration)
-1. Run the deployment script from the `tkg` directory:
+1. Run the deployment script from the `tkg` directory, either:
+
+    ```bash
+    ADMIN_EMAIL=<admin-email> ADMIN_PASSWORD=<admin-password> ./deploy.sh <app-name>
+    ```
+
+    or, to use the default admin credentials (`email@example.com` and `password`):
 
     ```bash
     ./deploy.sh <app-name>
     ```
+
 1. Keep note of the application url output by the deployment script, going forward referred to as `tkg-url` 
 1. Log in to the admin dashboard at `<tkg-url>/admin` (email: `email@example.com` and password: `password`)
 1. Create a retro for yourself by clicking on 'Retros' and then 'New Retro'
@@ -139,16 +155,22 @@ If you are on a **later version than 4.3.0** and using Postgres, Redis is no lon
 
 #### Initial deployment
 
-1. Set yourself up with an organization and space in your CF to deploy your Postfacto to.
+1. Set yourself up with an organization and space in your CF to deploy your Postfacto to
 1. Take note of your CF url, going forward referred to as `cf-url`
-1. Add a database (Postgres or Mysql) and a Redis service instance to your space from the Marketplace. Name these services `postfacto-db` and `postfacto-redis`.
-1. Run the CF deployment script from the `cf` directory:
+1. Add a database (Postgres or Mysql) and a Redis service instance to your space from the Marketplace; name these services `postfacto-db` and `postfacto-redis`
+1. Run the CF deployment script from the `cf` directory, either:
+
+    ```bash
+    ADMIN_EMAIL=<admin-email> ADMIN_PASSWORD=<admin-password> ./deploy.sh <app-name>
+    ```
+
+    or, to use the default admin credentials (`email@example.com` and `password`):
 
     ```bash
     ./deploy.sh <app-name>
     ```
 
-1. Log in to the Postfacto admin dashboard (email: `email@example.com` and password: `password`) to check everything has worked at `<app-name>.<cf-url>/admin`
+1. Log in to the Postfacto admin dashboard to check everything has worked at `<app-name>.<cf-url>/admin`
 1. Create a retro for yourself by clicking on 'Retros' and then 'New Retro'
 1. Log in to your retro at `<app-name>.<cf-url>/retros/your-retro-slug`
 1. Share the URL and password with your team and then run a retro!
@@ -173,13 +195,21 @@ If you are on a **later version than 4.3.0** and using Postgres, Redis is no lon
 #### Initial deployment
 
 1. Install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)
-1. Run the Heroku deployment script from the `heroku` directory:
+1. Run the Heroku deployment script from the `heroku` directory, either:
+
+    ```bash
+    ADMIN_EMAIL=<admin-email> ADMIN_PASSWORD=<admin-password> ./deploy.sh <app-name>
+    ```
+
+    or, to use the default admin credentials (`email@example.com` and `password`):
 
     ```bash
     ./deploy.sh <app-name>
     ```
 
-1. Log in to the Postfacto admin dashboard (email: `email@example.com` and password: `password`) to check everything has worked at `<app-name>.herokuapp.com/admin`
+    If you want to deploy to the EU [region](https://devcenter.heroku.com/articles/regions), rather than the default US region, prefix the deploy command with `HEROKU_REGION=eu`
+
+1. Log in to the Postfacto admin dashboard to check everything has worked at `<app-name>.herokuapp.com/admin`
 1. Create a retro for yourself by clicking on 'Retros' and then 'New Retro'
 1. Log in to your retro at `<app-name>.herokuapp.com/retros/your-retro-slug`
 1. Share the URL and password with your team and then run a retro!

--- a/deployment/deploy-cf.sh
+++ b/deployment/deploy-cf.sh
@@ -42,6 +42,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 APP_HOST=$1
 SESSION_TIME=${SESSION_TIME:-'""'}
+ADMIN_EMAIL="${ADMIN_EMAIL:-email@example.com}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-password}"
 
 ASSETS_DIR="$SCRIPT_DIR/../assets"
 CONFIG_DIR="$SCRIPT_DIR/config"
@@ -51,5 +53,5 @@ cf target \
     && exit 1)
 
 cp "$CONFIG_DIR/config.js" "$ASSETS_DIR/client/config.js"
-cf push -f "$CONFIG_DIR"/manifest.yml -p "$ASSETS_DIR" --var api-app-name=$APP_HOST --var session-time=$SESSION_TIME
-cf run-task $APP_HOST 'ADMIN_EMAIL=email@example.com ADMIN_PASSWORD=password rake admin:create_user'
+cf push -f "$CONFIG_DIR"/manifest.yml -p "$ASSETS_DIR" --var "api-app-name=$APP_HOST" --var "session-time=$SESSION_TIME"
+cf run-task "$APP_HOST" "ADMIN_EMAIL=$ADMIN_EMAIL ADMIN_PASSWORD=$ADMIN_PASSWORD rake admin:create_user"

--- a/deployment/deploy-heroku.sh
+++ b/deployment/deploy-heroku.sh
@@ -43,6 +43,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 APP_HOST=$1
 SESSION_TIME=${SESSION_TIME:-'""'}
+ADMIN_EMAIL="${ADMIN_EMAIL:-email@example.com}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-password}"
 HEROKU_REGION=${HEROKU_REGION:-'us'}
 
 ASSETS_DIR="$SCRIPT_DIR/../assets"
@@ -57,15 +59,15 @@ cp "$CONFIG_DIR/Procfile" "$ASSETS_DIR"
 ###################
 
 pushd "$ASSETS_DIR"
-  heroku create ${APP_HOST} --buildpack https://github.com/heroku/heroku-buildpack-ruby.git#v227 --region ${HEROKU_REGION}
-  heroku addons:create heroku-postgresql:hobby-dev -a ${APP_HOST}
-  heroku addons:create heroku-redis:hobby-dev -a ${APP_HOST}
-  heroku config:set WEBSOCKET_PORT=4443 SESSION_TIME=${SESSION_TIME} -a ${APP_HOST}
+  heroku create "$APP_HOST" --buildpack https://github.com/heroku/heroku-buildpack-ruby.git#v227 --region "$HEROKU_REGION"
+  heroku addons:create heroku-postgresql:hobby-dev -a "$APP_HOST"
+  heroku addons:create heroku-redis:hobby-dev -a "$APP_HOST"
+  heroku config:set WEBSOCKET_PORT=4443 "SESSION_TIME=$SESSION_TIME" -a "$APP_HOST"
 
   rm -rf .git # blow away any existent git directory from a previous run
   git init .
   git add .
   git commit -m "Packaging for initial Heroku deployment"
-  git push --set-upstream https://git.heroku.com/${APP_HOST}.git main
-  heroku run rake admin:create_user ADMIN_EMAIL=email@example.com ADMIN_PASSWORD=password -a ${APP_HOST} -x
+  git push --set-upstream "https://git.heroku.com/$APP_HOST.git" main
+  heroku run rake admin:create_user "ADMIN_EMAIL=$ADMIN_EMAIL" "ADMIN_PASSWORD=$ADMIN_PASSWORD" -a "$APP_HOST" -x
 popd

--- a/deployment/deploy-tas.sh
+++ b/deployment/deploy-tas.sh
@@ -41,6 +41,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 "$SCRIPT_DIR/mixpanel.sh" "TAS $(basename "${BASH_SOURCE[0]}")" "$@"
 
 APP_HOST=$1
+ADMIN_EMAIL="${ADMIN_EMAIL:-email@example.com}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-password}"
 SESSION_TIME=${SESSION_TIME:-'""'}
 
 ASSETS_DIR="$SCRIPT_DIR/../assets"
@@ -51,5 +53,5 @@ cf target \
     && exit 1)
 
 cp "$CONFIG_DIR/config.js" "$ASSETS_DIR/client/config.js"
-cf push -f "$CONFIG_DIR"/manifest.yml -p "$ASSETS_DIR" --var api-app-name=$APP_HOST --var session-time=$SESSION_TIME
-cf run-task $APP_HOST 'ADMIN_EMAIL=email@example.com ADMIN_PASSWORD=password rake admin:create_user'
+cf push -f "$CONFIG_DIR"/manifest.yml -p "$ASSETS_DIR" --var "api-app-name=$APP_HOST" --var "session-time=$SESSION_TIME"
+cf run-task "$APP_HOST" "ADMIN_EMAIL=$ADMIN_EMAIL ADMIN_PASSWORD=$ADMIN_PASSWORD rake admin:create_user"

--- a/run.sh
+++ b/run.sh
@@ -35,8 +35,8 @@ export RAILS_ENV="development"
 
 # Parse configuration
 
-ADMIN_USER="${ADMIN_USER:-email@example.com}"
-ADMIN_PASS="${ADMIN_PASS:-password}"
+ADMIN_EMAIL="${ADMIN_EMAIL:-email@example.com}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-password}"
 
 INFO=""
 
@@ -58,7 +58,7 @@ fi
 pushd "$BASE_DIR/api" >/dev/null
   echo "Migrating database..."
   bundle exec rake db:create db:migrate
-  ADMIN_EMAIL="$ADMIN_USER" ADMIN_PASSWORD="$ADMIN_PASS" bundle exec rake admin:create_user
+  ADMIN_EMAIL="$ADMIN_EMAIL" ADMIN_PASSWORD="$ADMIN_PASSWORD" bundle exec rake admin:create_user
 popd >/dev/null
 
 export USE_MOCK_GOOGLE
@@ -80,7 +80,7 @@ if [[ "$USE_MOCK_GOOGLE" == "true" ]]; then
 fi
 
 INFO+=$'\n'
-INFO+="Created admin user '$ADMIN_USER' with password '$ADMIN_PASS'"$'\n'
+INFO+="Created admin user '$ADMIN_EMAIL' with password '$ADMIN_PASSWORD'"$'\n'
 INFO+="Log in to http://localhost:4000/admin to administer"$'\n'
 INFO+="App will be available at http://localhost:3000/"$'\n'
 INFO+="Press 'q' to stop all services"


### PR DESCRIPTION
Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

    - Adds handling of `ADMIN_EMAIL` and `ADMIN_PASSWORD` env vars to deploy scripts
    - Documents `HEROKU_REGION` env var

* An explanation of the use cases your change solves

    Allows a more secure Postfacto installation by allowing the user to override the default admin credentials rather than have to reset them once installed.

* Links to any other associated PRs

    - Documents issue identified in #346
    - Supersedes #368

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
