### PR TITLE
Fix the Docker push scripts

### DIFF
--- a/docker/ci-push
+++ b/docker/ci-push
@@ -28,24 +28,29 @@
 # You should have received a copy of the GNU Affero General Public License
 #
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-set -e
+#
+set -euo pipefail
+
+IMAGE="${IMAGE:-build-image}"
+NAME="${NAME:-postfacto}"
+REPOSITORY="postfacto/$NAME"
+
+if [[ $# -ne 1 ]]; then
+  echo 'usage: ./ci-push <tag>'
+  echo "This will tag and deploy $IMAGE as $REPOSITORY"
+  exit 1
+fi
 
 TAG=$1
-REPOSITORY=postfacto/postfacto
-VERSION_TAG="$REPOSITORY:$TAG"
-LATEST_TAG="$REPOSITORY:latest"
+MAJOR="$(echo "$TAG" | cut -d. -f1)"
+MINOR="$(echo "$TAG" | cut -d. -f2)"
 
-echo "Tagging: $VERSION_TAG"
-docker tag build-image $VERSION_TAG
+for VERSION_TAG in 'latest' "$MAJOR" "$MAJOR.$MINOR" "$TAG"; do
+  echo "Tagging: $REPOSITORY:$VERSION_TAG"
+  docker tag "$IMAGE" "$REPOSITORY:$VERSION_TAG"
+done
 
-echo "Tagging: $LATEST_TAG"
-docker tag build-image $LATEST_TAG
-
-#docker login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD"
 echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
 
-echo "Pushing tag: $VERSION_TAG"
-docker push $VERSION_TAG
-
-echo "Pushing tag: $LATEST_TAG"
-docker push $LATEST_TAG
+echo 'Pushing tags'
+docker push "$REPOSITORY"

--- a/docker/ci-push-smoke
+++ b/docker/ci-push-smoke
@@ -1,21 +1,44 @@
 #!/bin/bash
-set -e
+#
+# Postfacto, a free, open-source and self-hosted retro tool aimed at helping
+# remote teams.
+#
+# Copyright (C) 2016 - Present Pivotal Software, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+#
+# it under the terms of the GNU Affero General Public License as
+#
+# published by the Free Software Foundation, either version 3 of the
+#
+# License, or (at your option) any later version.
+#
+#
+#
+# This program is distributed in the hope that it will be useful,
+#
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+#
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#
+# GNU Affero General Public License for more details.
+#
+#
+#
+# You should have received a copy of the GNU Affero General Public License
+#
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+set -euo pipefail
 
-TAG=$1
-REPOSITORY=postfacto/smoke
-VERSION_TAG="$REPOSITORY:$TAG"
-LATEST_TAG="$REPOSITORY:latest"
+IMAGE='build-image-smoke'
+NAME='smoke'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "Tagging: $VERSION_TAG"
-docker tag build-image-smoke $VERSION_TAG
+if [[ $# -ne 1 ]]; then
+  echo 'usage: ./ci-push-smoke <tag>'
+  echo "This will tag and deploy $IMAGE as postfacto/$NAME"
+  exit 1
+fi
 
-echo "Tagging: $LATEST_TAG"
-docker tag build-image-smoke $LATEST_TAG
-
-echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
-
-echo "Pushing tag: $VERSION_TAG"
-docker push $VERSION_TAG
-
-echo "Pushing tag: $LATEST_TAG"
-docker push $LATEST_TAG
+IMAGE="$IMAGE" NAME="$NAME" "$SCRIPT_DIR/ci-push" "$1"


### PR DESCRIPTION


Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

    - Make the scripts executable
    - De-duplicate logic
    - Tag version `x.y.z` as `x`, `x.y` and `x.y.z`

* An explanation of the use cases your change solves

    Currently new versions can't be released to Docker Hub because the scripts aren't executable. Providing extra tags allows people to use e.g. `postfacto:postfacto:4.3` and benefit from patch updates.

* Links to any other associated PRs

    N/A

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
