### PR TITLE
Allow creation of sharable retro from admin panel (fixes #308)

### DIFF
--- a/api/app/admin/retros.rb
+++ b/api/app/admin/retros.rb
@@ -70,6 +70,8 @@ ActiveAdmin.register Retro do
 
     column('Private', :is_private)
 
+    column('Magic Link', :is_magic_link_enabled)
+
     column('User', :user)
     actions
   end
@@ -133,7 +135,7 @@ ActiveAdmin.register Retro do
       f.input :video_link
       f.input :owner_email
       f.input :is_private
-      f.input :magic_link_enabled, as: :boolean
+      f.input :is_magic_link_enabled, as: :boolean
     end
 
     f.inputs do

--- a/api/config/locales/en.yml
+++ b/api/config/locales/en.yml
@@ -72,7 +72,7 @@ en:
     labels:
       retro:
         is_private: "Make this retro private?"
-        magic_link_enabled: "Share this retro using a magic link?"
+        is_magic_link_enabled: "Share this retro using a magic link?"
         owner_email: "Owner Email"
     hints:
       retro:

--- a/api/spec/admin/admin_retros_request_spec.rb
+++ b/api/spec/admin/admin_retros_request_spec.rb
@@ -129,6 +129,7 @@ describe '/admin/retros', type: :request do
                               'Ordered By',
                               'Password',
                               'Private',
+                              'Magic Link',
                               'User'
                             ])
     end
@@ -151,6 +152,7 @@ describe '/admin/retros', type: :request do
       expect(data[11]).to eq('the-video-link')
       expect(data[13]).to include('Yes')
       expect(data[14]).to include('Yes')
+      expect(data[15]).to include('No')
     end
 
     it 'has a filter for public/private retros' do

--- a/e2e.sh
+++ b/e2e.sh
@@ -119,7 +119,7 @@ popd >/dev/null
 
 pushd "$BASE_DIR/e2e" >/dev/null
   echo 'Running E2E tests...'
-  bundle exec rspec $1
+  bundle exec rspec "$@"
 popd >/dev/null
 
 # Shutdown services

--- a/e2e/spec/felicity_journey_spec.rb
+++ b/e2e/spec/felicity_journey_spec.rb
@@ -252,6 +252,18 @@ context 'Felicity', type: :feature, js: true, if: ENV['USE_MOCK_GOOGLE'] == 'tru
     end
   end
 
+  context 'from admin panel' do
+    specify 'sharing a retro' do
+      slug = 'i-can-be-shared'
+      password = 'opensesame'
+      create_sharable_retro_as_admin(slug, password)
+      visit "#{RETRO_APP_BASE_URL}/retros/#{slug}"
+      fill_in 'Password', with: password
+      click_on 'Login'
+      expect(get_share_url).to include "/retros/#{slug}/join/"
+    end
+  end
+
   specify 'Auto facilitation journey' do
     register('felicity-auto-facilitate-user')
     create_public_retro

--- a/e2e/spec/spec_helper.rb
+++ b/e2e/spec/spec_helper.rb
@@ -86,6 +86,17 @@ module SpecHelpers
     page.driver.execute_script("window.localStorage.setItem('authToken', 'secret-test-user-token-ef87c521b979');")
   end
 
+  def create_sharable_retro_as_admin(slug, password)
+    login_as_admin
+    click_on 'Retros'
+    click_on 'New Retro'
+    fill_in 'Name', with: 'Sharable retro'
+    fill_in 'Slug', with: slug
+    fill_in 'Password', with: password
+    page.check 'Share this retro using a magic link?'
+    click_on 'Create Retro'
+  end
+
   def create_private_retro(team_name = nil)
     fill_in_create_retro_form(team_name)
     find('#retro_is_magic_link_enabled', visible: :all).set(true)


### PR DESCRIPTION
Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

    - Change the name of the checkbox input for enabling the magic link to `retro[is_magic_link_enabled]` in the admin panel
    - Show whether a retro has the magic link enabled in the admin panel

* An explanation of the use cases your change solves

    Allows creation of a retro with a magic link from the admin panel

* Links to any other associated PRs

    Fixes #308

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [ ] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
