### PR TITLE
Need to be compatible with cf CLI v7

### DIFF
--- a/deployment/deploy-cf.sh
+++ b/deployment/deploy-cf.sh
@@ -54,4 +54,13 @@ cf target \
 
 cp "$CONFIG_DIR/config.js" "$ASSETS_DIR/client/config.js"
 cf push -f "$CONFIG_DIR"/manifest.yml -p "$ASSETS_DIR" --var "api-app-name=$APP_HOST" --var "session-time=$SESSION_TIME"
-cf run-task "$APP_HOST" "ADMIN_EMAIL=$ADMIN_EMAIL ADMIN_PASSWORD=$ADMIN_PASSWORD rake admin:create_user"
+
+
+CF_VERSION="$(cf -v | awk '{print $3}' | awk -F '.' '{print $1}')"
+TASK_COMMAND="ADMIN_EMAIL=$ADMIN_EMAIL ADMIN_PASSWORD=$ADMIN_PASSWORD rake admin:create_user"
+
+if [ $CF_VERSION -ge 7 ]; then
+  TASK_COMMAND="--command $TASK_COMMAND"
+fi
+
+cf run-task "$APP_HOST" "$TASK_COMMAND"

--- a/deployment/deploy-cf.sh
+++ b/deployment/deploy-cf.sh
@@ -60,7 +60,7 @@ CF_VERSION="$(cf -v | awk '{print $3}' | awk -F '.' '{print $1}')"
 TASK_COMMAND="ADMIN_EMAIL=$ADMIN_EMAIL ADMIN_PASSWORD=$ADMIN_PASSWORD rake admin:create_user"
 
 if [ $CF_VERSION -ge 7 ]; then
-  TASK_COMMAND="--command $TASK_COMMAND"
+  cf run-task "$APP_HOST" --command "$TASK_COMMAND"
+else
+  cf run-task "$APP_HOST" "$TASK_COMMAND"
 fi
-
-cf run-task "$APP_HOST" "$TASK_COMMAND"

--- a/deployment/deploy-tas.sh
+++ b/deployment/deploy-tas.sh
@@ -59,7 +59,7 @@ CF_VERSION="$(cf -v | awk '{print $3}' | awk -F '.' '{print $1}')"
 TASK_COMMAND="ADMIN_EMAIL=$ADMIN_EMAIL ADMIN_PASSWORD=$ADMIN_PASSWORD rake admin:create_user"
 
 if [ $CF_VERSION -ge 7 ]; then
-  TASK_COMMAND="--command $TASK_COMMAND"
+  cf run-task "$APP_HOST" --command "$TASK_COMMAND"
+else
+  cf run-task "$APP_HOST" "$TASK_COMMAND"
 fi
-
-cf run-task "$APP_HOST" "$TASK_COMMAND"

--- a/deployment/deploy-tas.sh
+++ b/deployment/deploy-tas.sh
@@ -54,4 +54,12 @@ cf target \
 
 cp "$CONFIG_DIR/config.js" "$ASSETS_DIR/client/config.js"
 cf push -f "$CONFIG_DIR"/manifest.yml -p "$ASSETS_DIR" --var "api-app-name=$APP_HOST" --var "session-time=$SESSION_TIME"
-cf run-task "$APP_HOST" "ADMIN_EMAIL=$ADMIN_EMAIL ADMIN_PASSWORD=$ADMIN_PASSWORD rake admin:create_user"
+
+CF_VERSION=`cf -v | awk '{print $3}' | awk -F '.' '{print $1}'`
+TASK_COMMAND="ADMIN_EMAIL=$ADMIN_EMAIL ADMIN_PASSWORD=$ADMIN_PASSWORD rake admin:create_user"
+
+if [ $CF_VERSION -ge 7 ]; then
+  TASK_COMMAND="--command $TASK_COMMAND"
+fi
+
+cf run-task "$APP_HOST" "$TASK_COMMAND"

--- a/deployment/deploy-tas.sh
+++ b/deployment/deploy-tas.sh
@@ -55,7 +55,7 @@ cf target \
 cp "$CONFIG_DIR/config.js" "$ASSETS_DIR/client/config.js"
 cf push -f "$CONFIG_DIR"/manifest.yml -p "$ASSETS_DIR" --var "api-app-name=$APP_HOST" --var "session-time=$SESSION_TIME"
 
-CF_VERSION=`cf -v | awk '{print $3}' | awk -F '.' '{print $1}'`
+CF_VERSION="$(cf -v | awk '{print $3}' | awk -F '.' '{print $1}')"
 TASK_COMMAND="ADMIN_EMAIL=$ADMIN_EMAIL ADMIN_PASSWORD=$ADMIN_PASSWORD rake admin:create_user"
 
 if [ $CF_VERSION -ge 7 ]; then


### PR DESCRIPTION
In the case of cf CLI v7, we need to add "--command" option to specify command with "cf run-task" command while we don't need it in the case of cf CLI v6.

Current version of deploy.sh for TAS doesn't have "--command" option with "cf run-task" and it does not work with cf CLI v7.

I propose to modify deploy.sh script for TAS to enable deploy Postfacto with cf CLI v7 as well as cf CLI v6

Thanks for contributing to Postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [ ] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
