### PR TITLE
Add and test toggle for sorting column items by the number of votes

### DIFF
--- a/humans.txt
+++ b/humans.txt
@@ -61,3 +61,6 @@ Contact: mike.kenyon@gmail.com
 
 Engineer: Max Brauer
 Contact: github.com/mamachanko
+
+Engineer: Nick Hagi
+Contact: github.com/nickkhg

--- a/web/src/components/retro-show/retro_column.jsx
+++ b/web/src/components/retro-show/retro_column.jsx
@@ -48,6 +48,7 @@ export default class RetroColumn extends React.Component {
     retro: types.object.isRequired,
     retroId: types.string.isRequired,
     archives: types.bool,
+    sortsByVotes: types.bool,
     isMobile: types.bool.isRequired,
     voteRetroItem: types.func.isRequired,
     doneRetroItem: types.func.isRequired,
@@ -63,7 +64,18 @@ export default class RetroColumn extends React.Component {
 
   static defaultProps = {
     archives: false,
+    sortsByVotes: false,
   };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      sortsByVotes: props.sortsByVotes,
+    };
+
+    this.toggleItemSorting = this.toggleItemSorting.bind(this);
+  }
 
   renderRetroItems() {
     const {
@@ -74,13 +86,17 @@ export default class RetroColumn extends React.Component {
       isMobile,
     } = this.props;
 
+    const {
+      sortsByVotes,
+    } = this.state;
+
     if (!items) {
       return null;
     }
 
     return items
       .filter((item) => item.category === category)
-      .sort((a, b) => (b.created_at <= a.created_at ? -1 : 1))
+      .sort((a, b) => ((sortsByVotes ? (b.vote_count <= a.vote_count) : (b.created_at <= a.created_at)) ? -1 : 1))
       .map((item) => (
         <RetroColumnItem
           key={item.id}
@@ -120,13 +136,30 @@ export default class RetroColumn extends React.Component {
       return null;
     }
     return (
-      <RetroColumnInput
-        retroId={retroId}
-        category={category}
-        createRetroItem={this.props.createRetroItem}
-        createRetroActionItem={this.props.createRetroActionItem}
-      />
+      <div className="column-input-header">
+        <RetroColumnInput
+          retroId={retroId}
+          category={category}
+          createRetroItem={this.props.createRetroItem}
+          createRetroActionItem={this.props.createRetroActionItem}
+        />
+        <div className="sort-items-toggle">
+          <div className={'sort-items-toggle-submit-' + this.resolveSortingClass()} onClick={this.toggleItemSorting}>
+            <div className="vote-icon"><i className="fa fa-heart" aria-hidden="true"/></div>
+          </div>
+        </div>
+      </div>
     );
+  }
+
+  toggleItemSorting() {
+    const {sortsByVotes} = this.state;
+    this.setState({sortsByVotes: !sortsByVotes});
+  }
+
+  resolveSortingClass() {
+    const {sortsByVotes} = this.state;
+    return sortsByVotes ? 'active' : 'inactive';
   }
 
   render() {

--- a/web/src/components/retro-show/retro_column.test.jsx
+++ b/web/src/components/retro-show/retro_column.test.jsx
@@ -46,14 +46,14 @@ const retro = {
       description: 'the happy retro item',
       category: 'happy',
       created_at: '2016-07-19T00:00:00.000Z',
-      vote_count: 10,
+      vote_count: 9,
     },
     {
       id: 2,
       description: 'the 2nd happy retro item',
       category: 'happy',
       created_at: '2016-07-18T00:00:00.000Z',
-      vote_count: 9,
+      vote_count: 10,
     },
     {
       id: 3,
@@ -67,11 +67,12 @@ const retro = {
     },
   ],
 };
-describe('RetroColumn', () => {
+
+describe('RetroColumnSortedByTime', () => {
   let dom;
 
   beforeEach(() => {
-    dom = mount(<RetroColumn retro={retro} retroId="retro-slug-123" category="happy" isMobile={false} createRetroActionItem={goof} createRetroItem={goof} deleteRetroItem={goof} doneRetroItem={goof} extendTimer={goof} highlightRetroItem={goof} undoneRetroItem={goof} unhighlightRetroItem={goof} updateRetroItem={goof} voteRetroItem={goof}/>);
+    dom = mount(<RetroColumn retro={retro} retroId="retro-slug-123" category="happy" sortsByVotes={false} isMobile={false} createRetroActionItem={goof} createRetroItem={goof} deleteRetroItem={goof} doneRetroItem={goof} extendTimer={goof} highlightRetroItem={goof} undoneRetroItem={goof} unhighlightRetroItem={goof} updateRetroItem={goof} voteRetroItem={goof}/>);
   });
 
   it('assigns a class name based on category', () => {
@@ -87,5 +88,28 @@ describe('RetroColumn', () => {
     const happyItems = dom.find('.retro-item .item-text');
     expect(happyItems.at(0)).toHaveText('the happy retro item');
     expect(happyItems.at(1)).toHaveText('the 2nd happy retro item');
+  });
+});
+
+describe('RetroColumnSortedByVotes', () => {
+  let dom;
+
+  beforeEach(() => {
+    dom = mount(<RetroColumn retro={retro} retroId="retro-slug-123" category="happy" sortsByVotes={true} isMobile={false} createRetroActionItem={goof} createRetroItem={goof} deleteRetroItem={goof} doneRetroItem={goof} extendTimer={goof} highlightRetroItem={goof} undoneRetroItem={goof} unhighlightRetroItem={goof} updateRetroItem={goof} voteRetroItem={goof}/>);
+  });
+
+  it('assigns a class name based on category', () => {
+    expect(dom.find('.column-happy')).toExist();
+  });
+
+  it('displays all items', () => {
+    expect(dom.find('textarea.retro-item-add-input').prop('placeholder')).toEqual('I\'m glad that...');
+    expect(dom.find('.retro-item')).toHaveLength(2);
+  });
+
+  it('displays items ordered by votes', () => {
+    const happyItems = dom.find('.retro-item .item-text');
+    expect(happyItems.at(0)).toHaveText('the 2nd happy retro item');
+    expect(happyItems.at(1)).toHaveText('the happy retro item');
   });
 });

--- a/web/src/components/retro-show/retro_column.test.jsx
+++ b/web/src/components/retro-show/retro_column.test.jsx
@@ -95,7 +95,7 @@ describe('RetroColumnSortedByVotes', () => {
   let dom;
 
   beforeEach(() => {
-    dom = mount(<RetroColumn retro={retro} retroId="retro-slug-123" category="happy" sortsByVotes={true} isMobile={false} createRetroActionItem={goof} createRetroItem={goof} deleteRetroItem={goof} doneRetroItem={goof} extendTimer={goof} highlightRetroItem={goof} undoneRetroItem={goof} unhighlightRetroItem={goof} updateRetroItem={goof} voteRetroItem={goof}/>);
+    dom = mount(<RetroColumn retro={retro} retroId="retro-slug-123" category="happy" sortsByVotes isMobile={false} createRetroActionItem={goof} createRetroItem={goof} deleteRetroItem={goof} doneRetroItem={goof} extendTimer={goof} highlightRetroItem={goof} undoneRetroItem={goof} unhighlightRetroItem={goof} updateRetroItem={goof} voteRetroItem={goof}/>);
   });
 
   it('assigns a class name based on category', () => {

--- a/web/src/stylesheets/_app.scss
+++ b/web/src/stylesheets/_app.scss
@@ -373,6 +373,7 @@ ol ol > li:before {
 .retro-item-list-input {
   padding-top: 0.5rem;
   margin-bottom: 1rem;
+  width: 100%;
 }
 
 .retro-item:hover {
@@ -779,6 +780,31 @@ button:focus {
 .retro-action-edit .action-text {
   @extend .small-12;
   padding: 0;
+}
+
+.column-input-header {
+  display:flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+
+.sort-items-toggle-submit-inactive {
+  &:hover {
+    color: $highlight;
+    cursor: pointer;
+  }
+  padding-left: 8px;
+  margin-right: 0;
+}
+.sort-items-toggle-submit-active {
+  &:hover {
+    color: $highlight;
+    cursor: pointer;
+  }
+  color: $white;
+  padding-left: 8px;
+  margin-right: 0;
 }
 
 .item-content, .action-content {


### PR DESCRIPTION
Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
This PR adds a toggle button on the retro page which allows the client to sort the list of items in each column by the number of votes it has received.

* An explanation of the use cases your change solves
This is useful for the discussions that follow the addition of items, so that the conversations can be held in order of importance, as voted by the team. Oftentimes the columns can get quite long, so having this simple feature could help a lot.

* Links to any other associated PRs (-)

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [N/A] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
