### PR TITLE
Allow CLIENT_ORIGIN to be set

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -51,6 +51,11 @@ that is the same across upgrades:
 
 * `secretKeyBase=<random-long-value>`
 
+### Allow websocket connections
+To allow realtime updates via websocket connections, you need to set the URL that connections will be accepted from. In a public facing deployment, this is usually the public facing URL:
+
+* `clientOrigin=https://<host>`
+
 
 # Upgrading
 Upgrading is similar to installing, make sure you provide the same passwords 
@@ -65,11 +70,12 @@ helm upgrade postfacto . \
 
 ## Postfacto parameters
 
-Parameter | Description | Default
-----------|-------------|--------
-googleOAuthClientId  | The Google oAuth client ID to use to allow users to log in using a google account | nil   
-disableSSLRedirect  | By default Postfacto redirects to HTTPS by default, setting this to true disables that behaviour and can be useful when getting started | nil   
-secretKeyBase | Used for signing and encryption, should be set to a random value | random 10 character alpha numeric string
+Parameter | Description                                                                                                                             | Default
+----------|-----------------------------------------------------------------------------------------------------------------------------------------|--------
+googleOAuthClientId  | The Google oAuth client ID to use to allow users to log in using a google account                                                       | nil
+disableSSLRedirect  | By default Postfacto redirects to HTTPS by default, setting this to true disables that behaviour and can be useful when getting started | nil
+secretKeyBase | Used for signing and encryption, should be set to a random value                                                                        | random 10 character alpha numeric string
+clientOrigin | A URL to whitelist connections to                                                                                                       | nil
 
 ## Subcharts
 This chart includes the following subcharts: 

--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -84,6 +84,8 @@ spec:
             value: "redis://:$(REDIS_PASSWORD)@{{ .Release.Name }}-redis-master"
           - name: GOOGLE_OAUTH_CLIENT_ID
             value: "{{ .Values.googleOAuthClientId }}"
+          - name: CLIENT_ORIGIN
+            value: "{{ .Values.clientOrigin }}"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -65,6 +65,7 @@ nodeSelector: {}
 disableSSLRedirect:
 googleOAuthClientId:
 secretKeyBase:
+clientOrigin:
 
 redis:
   cluster:


### PR DESCRIPTION
Thanks for contributing to postfacto. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
**Allow CLIENT_ORIGIN to be set in helm deployment**

* An explanation of the use cases your change solves
**Allow websocket connections to be made**
See: https://github.com/pivotal/postfacto/issues/435

* Links to any other associated PRs
**none**

* [x] I have reviewed the [contributing guide](https://github.com/pivotal/postfacto/blob/master/CONTRIBUTING.md)

* [x] I have made this pull request to the `master` branch

* [x] I have run all the tests using `./test.sh`.

* [x] I have added the [copyright headers](https://github.com/pivotal/postfacto/blob/master/license-header.txt) to each new file added

* [x] I have given myself credit in the [humans.txt](https://github.com/pivotal/postfacto/blob/master/humans.txt) file (assuming I want to)
